### PR TITLE
feat: fix recurring task lifecycle and completion reply matching

### DIFF
--- a/src/handlers/complete.js
+++ b/src/handlers/complete.js
@@ -32,7 +32,14 @@ async function handleCompletionReply(ctx) {
     return true;
   }
 
-  const matches = queued.filter((task) => text.includes(task.title.toLowerCase()));
+  const tokens = text.split(",").map((s) => s.trim()).filter(Boolean);
+  const matches = queued.filter((task) => {
+    const title = task.title.toLowerCase();
+    // Full free text contains the exact task title ("I finished fix leaky tap today")
+    if (text.includes(title)) return true;
+    // Or any comma-separated short token is a substring of the task title ("leaky tap, lawn")
+    return tokens.some((token) => title.includes(token));
+  });
   if (matches.length > 0) {
     const count = await bulkComplete(matches.map((task) => task.id));
     endCompletionWindow(ctx.chat.id);

--- a/src/services/supabase.js
+++ b/src/services/supabase.js
@@ -87,6 +87,7 @@ async function updateTask(id, patch) {
 }
 
 async function getIncompleteTasksByPriority(householdId) {
+  const today = new Date().toISOString().slice(0, 10);
   const { data, error } = await supabase
     .from("tasks")
     .select("*")
@@ -96,6 +97,7 @@ async function getIncompleteTasksByPriority(householdId) {
   if (error) throw error;
   return data
     .map(fromDbTask)
+    .filter((t) => !t.isRecurring || !t.nextDueDate || t.nextDueDate <= today)
     .sort((a, b) => {
       const p = CRITICALITY_ORDER[a.criticality] - CRITICALITY_ORDER[b.criticality];
       if (p !== 0) return p;
@@ -106,13 +108,41 @@ async function getIncompleteTasksByPriority(householdId) {
 async function bulkComplete(ids) {
   if (!ids.length) return 0;
   const now = new Date().toISOString();
-  const { data, error } = await supabase
+  const today = now.slice(0, 10);
+
+  const { data: tasks, error: fetchError } = await supabase
     .from("tasks")
-    .update({ completed: true, completed_at: now, last_completed_at: now.slice(0, 10) })
-    .in("id", ids)
-    .select("id");
-  if (error) throw error;
-  return data.length;
+    .select("id, is_recurring, recurrence_interval_days")
+    .in("id", ids);
+  if (fetchError) throw fetchError;
+
+  const recurring = tasks.filter((t) => t.is_recurring);
+  const nonRecurring = tasks.filter((t) => !t.is_recurring);
+  let completed = 0;
+
+  if (nonRecurring.length) {
+    const { data, error } = await supabase
+      .from("tasks")
+      .update({ completed: true, completed_at: now, last_completed_at: today })
+      .in("id", nonRecurring.map((t) => t.id))
+      .select("id");
+    if (error) throw error;
+    completed += data.length;
+  }
+
+  for (const task of recurring) {
+    const intervalDays = task.recurrence_interval_days || 7;
+    const nextDue = new Date(Date.now() + intervalDays * 24 * 60 * 60 * 1000)
+      .toISOString().slice(0, 10);
+    const { error } = await supabase
+      .from("tasks")
+      .update({ last_completed_at: today, next_due_date: nextDue })
+      .eq("id", task.id);
+    if (error) throw error;
+    completed += 1;
+  }
+
+  return completed;
 }
 
 async function deleteTask(id) {

--- a/test/handlers/complete.test.js
+++ b/test/handlers/complete.test.js
@@ -111,6 +111,27 @@ describe('handleCompletionReply', () => {
     assert.equal(endCompletionWindow.mock.calls.length, 1);
   });
 
+  it('comma-separated partial names match multiple tasks', async () => {
+    getQueuedTasks.mock.mockImplementation(() => TASKS);
+    // "leaky tap" is a substring of "Fix leaky tap"; "lawn" is a substring of "Mow lawn"
+    const ctx = makeCtx('leaky tap, lawn');
+    const result = await handleCompletionReply(ctx);
+    assert.equal(result, true);
+    const completedIds = bulkComplete.mock.calls[0].arguments[0];
+    assert.ok(completedIds.includes('task1'));
+    assert.ok(completedIds.includes('task2'));
+  });
+
+  it('single partial name token matches the right task', async () => {
+    getQueuedTasks.mock.mockImplementation(() => TASKS);
+    const ctx = makeCtx('leaky tap');
+    const result = await handleCompletionReply(ctx);
+    assert.equal(result, true);
+    const completedIds = bulkComplete.mock.calls[0].arguments[0];
+    assert.ok(completedIds.includes('task1'));
+    assert.ok(!completedIds.includes('task2'));
+  });
+
   it('returns false when text has no matching task names', async () => {
     getQueuedTasks.mock.mockImplementation(() => TASKS);
     const ctx = makeCtx('random unrelated text');

--- a/test/unit/supabase.test.js
+++ b/test/unit/supabase.test.js
@@ -1,0 +1,200 @@
+'use strict';
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+// ─── Supabase client mock ────────────────────────────────────────────────────
+// The supabase client uses a fluent builder: from().select().in() etc.
+// We queue responses so each top-level from() call dequeues the next one.
+
+let responseQueue = [];
+
+function makeFakeChain(result) {
+  const chain = {
+    select: () => chain,
+    update: () => chain,
+    delete: () => chain,
+    insert: () => chain,
+    upsert: () => chain,
+    in: () => chain,
+    eq: () => chain,
+    is: () => chain,
+    gt: () => chain,
+    or: () => chain,
+    order: () => chain,
+    maybeSingle: async () => result,
+    single: async () => result,
+    then: (resolve, reject) => Promise.resolve(result).then(resolve, reject)
+  };
+  return chain;
+}
+
+const fakeSupabase = {
+  from: () => {
+    const result = responseQueue.shift() ?? { data: [], error: null };
+    return makeFakeChain(result);
+  }
+};
+
+require.cache[require.resolve('@supabase/supabase-js')] = {
+  exports: { createClient: () => fakeSupabase }
+};
+require.cache[require.resolve('../../src/config')] = {
+  exports: {
+    config: {
+      supabaseUrl: 'http://fake',
+      supabaseServiceRoleKey: 'fake-key'
+    }
+  }
+};
+
+const { bulkComplete, getIncompleteTasksByPriority } = require('../../src/services/supabase');
+
+// ─── bulkComplete ─────────────────────────────────────────────────────────────
+
+describe('bulkComplete', () => {
+  beforeEach(() => { responseQueue = []; });
+
+  it('returns 0 immediately for empty id list', async () => {
+    const count = await bulkComplete([]);
+    assert.equal(count, 0);
+    assert.equal(responseQueue.length, 0); // no DB calls made
+  });
+
+  it('permanently completes non-recurring tasks', async () => {
+    // 1st call: fetch task metadata
+    responseQueue.push({ data: [{ id: 't1', is_recurring: false, recurrence_interval_days: null }], error: null });
+    // 2nd call: update non-recurring tasks (returns the updated rows)
+    responseQueue.push({ data: [{ id: 't1' }], error: null });
+
+    const count = await bulkComplete(['t1']);
+    assert.equal(count, 1);
+    // responseQueue should be drained
+    assert.equal(responseQueue.length, 0);
+  });
+
+  it('advances next_due_date for recurring tasks without marking completed', async () => {
+    // 1st call: fetch task metadata
+    responseQueue.push({
+      data: [{ id: 'r1', is_recurring: true, recurrence_interval_days: 7 }],
+      error: null
+    });
+    // 2nd call: update recurring task (no select, returns { error: null })
+    responseQueue.push({ error: null });
+
+    const count = await bulkComplete(['r1']);
+    assert.equal(count, 1);
+    assert.equal(responseQueue.length, 0);
+  });
+
+  it('handles mixed recurring and non-recurring in one call', async () => {
+    // fetch metadata: one non-recurring, one recurring
+    responseQueue.push({
+      data: [
+        { id: 't1', is_recurring: false, recurrence_interval_days: null },
+        { id: 'r1', is_recurring: true, recurrence_interval_days: 3 }
+      ],
+      error: null
+    });
+    // update non-recurring batch
+    responseQueue.push({ data: [{ id: 't1' }], error: null });
+    // update recurring (one per task)
+    responseQueue.push({ error: null });
+
+    const count = await bulkComplete(['t1', 'r1']);
+    assert.equal(count, 2);
+    assert.equal(responseQueue.length, 0);
+  });
+
+  it('uses 7-day default interval when recurrence_interval_days is null', async () => {
+    responseQueue.push({
+      data: [{ id: 'r1', is_recurring: true, recurrence_interval_days: null }],
+      error: null
+    });
+    responseQueue.push({ error: null });
+
+    // Should not throw; falls back to 7-day default
+    const count = await bulkComplete(['r1']);
+    assert.equal(count, 1);
+  });
+});
+
+// ─── getIncompleteTasksByPriority ─────────────────────────────────────────────
+
+describe('getIncompleteTasksByPriority', () => {
+  const today = new Date().toISOString().slice(0, 10);
+  const tomorrow = new Date(Date.now() + 86400000).toISOString().slice(0, 10);
+  const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+
+  function makeRow(overrides) {
+    return {
+      id: 'tid',
+      title: 'task',
+      area: 'kitchen',
+      criticality: 'MEDIUM',
+      effort_mins: 30,
+      tags: [],
+      assigned_to: 'Me',
+      deadline: null,
+      reasoning: null,
+      raw_input: null,
+      added_by: null,
+      completed: false,
+      completed_at: null,
+      is_recurring: false,
+      recurrence_interval_days: null,
+      next_due_date: null,
+      last_completed_at: null,
+      created_at: new Date().toISOString(),
+      ...overrides
+    };
+  }
+
+  beforeEach(() => { responseQueue = []; });
+
+  it('includes non-recurring tasks regardless of any date field', async () => {
+    responseQueue.push({ data: [makeRow({ id: 't1', is_recurring: false, next_due_date: tomorrow })], error: null });
+    const tasks = await getIncompleteTasksByPriority('h1');
+    assert.equal(tasks.length, 1);
+  });
+
+  it('includes recurring tasks due today', async () => {
+    responseQueue.push({ data: [makeRow({ id: 'r1', is_recurring: true, next_due_date: today })], error: null });
+    const tasks = await getIncompleteTasksByPriority('h1');
+    assert.equal(tasks.length, 1);
+  });
+
+  it('includes recurring tasks that are overdue (next_due_date < today)', async () => {
+    responseQueue.push({ data: [makeRow({ id: 'r1', is_recurring: true, next_due_date: yesterday })], error: null });
+    const tasks = await getIncompleteTasksByPriority('h1');
+    assert.equal(tasks.length, 1);
+  });
+
+  it('excludes recurring tasks with next_due_date in the future', async () => {
+    responseQueue.push({ data: [makeRow({ id: 'r1', is_recurring: true, next_due_date: tomorrow })], error: null });
+    const tasks = await getIncompleteTasksByPriority('h1');
+    assert.equal(tasks.length, 0);
+  });
+
+  it('includes recurring tasks when next_due_date is null', async () => {
+    responseQueue.push({ data: [makeRow({ id: 'r1', is_recurring: true, next_due_date: null })], error: null });
+    const tasks = await getIncompleteTasksByPriority('h1');
+    assert.equal(tasks.length, 1);
+  });
+
+  it('sorts tasks by criticality then effort', async () => {
+    responseQueue.push({
+      data: [
+        makeRow({ id: 'low', criticality: 'LOW', effort_mins: 10 }),
+        makeRow({ id: 'crit', criticality: 'CRITICAL', effort_mins: 60 }),
+        makeRow({ id: 'high-fast', criticality: 'HIGH', effort_mins: 15 }),
+        makeRow({ id: 'high-slow', criticality: 'HIGH', effort_mins: 45 })
+      ],
+      error: null
+    });
+    const tasks = await getIncompleteTasksByPriority('h1');
+    assert.equal(tasks[0].id, 'crit');
+    assert.equal(tasks[1].id, 'high-fast');
+    assert.equal(tasks[2].id, 'high-slow');
+    assert.equal(tasks[3].id, 'low');
+  });
+});


### PR DESCRIPTION
## Summary

- **Task 6 — Fix recurring task completion**: `bulkComplete` was permanently marking recurring tasks as `completed = true`, causing them to disappear forever. Now it splits tasks by `is_recurring`: non-recurring tasks are permanently completed; recurring tasks get `next_due_date` advanced by `recurrence_interval_days` (defaults to 7) and `last_completed_at` updated — `completed` stays `false` so they re-enter the queue on their next due date.

- **Task 7 — Filter queue by `next_due_date`**: `getIncompleteTasksByPriority` was returning all incomplete tasks regardless of `next_due_date`, so a recurring weekly task marked done on Monday would re-appear in Tuesday's queue. Now recurring tasks are filtered to only show when `next_due_date <= today` or when `next_due_date` is null.

- **Task 8 — Fix completion reply name matching**: The "no → which ones?" follow-up was broken for partial names. The match now uses two strategies combined: if the full task title appears in the user's free text ("I finished fix leaky tap today"), OR if any comma-separated token is a substring of the task title ("leaky tap, lawn").

## Test plan

- [ ] `npm test` passes (215 tests, 0 failures)
- [ ] Completing a non-recurring task via `/done` or the completion prompt marks it `completed = true`
- [ ] Completing a recurring task via `/done` or the completion prompt advances `next_due_date` and keeps `completed = false`
- [ ] A recurring task with `next_due_date = tomorrow` does not appear in `/pending` or today's queue
- [ ] A recurring task with `next_due_date = yesterday` (overdue) appears in `/pending`
- [ ] After saying "no" to the completion prompt, replying "fix leaky tap" completes that task
- [ ] After saying "no", replying "leaky, groceries" (partial names) matches the right tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)