### PR TITLE
feat: warn when household is missing settings and skipped by scheduler

### DIFF
--- a/src/services/supabase.js
+++ b/src/services/supabase.js
@@ -2,6 +2,7 @@ const crypto = require("crypto");
 const { createClient } = require("@supabase/supabase-js");
 const { config } = require("../config");
 const { CRITICALITY_ORDER, DEFAULT_AREA_SEED } = require("../constants");
+const { warn } = require("../utils/logger");
 
 const supabase = createClient(config.supabaseUrl, config.supabaseServiceRoleKey, {
   auth: { persistSession: false }
@@ -275,7 +276,13 @@ async function getAllHouseholdsWithSettings() {
     .is("deleted_at", null);
   if (error) throw error;
   return data
-    .filter((h) => Array.isArray(h.settings) && h.settings.length > 0)
+    .filter((h) => {
+      if (!Array.isArray(h.settings) || !h.settings.length) {
+        warn("household_missing_settings", { householdId: h.id, name: h.name });
+        return false;
+      }
+      return true;
+    })
     .map((h) => {
       const s = h.settings[0];
       return {

--- a/test/unit/supabase.test.js
+++ b/test/unit/supabase.test.js
@@ -47,7 +47,13 @@ require.cache[require.resolve('../../src/config')] = {
   }
 };
 
-const { bulkComplete, getIncompleteTasksByPriority } = require('../../src/services/supabase');
+const { mock } = require('node:test');
+const warnFn = mock.fn();
+require.cache[require.resolve('../../src/utils/logger')] = {
+  exports: { info: mock.fn(), warn: warnFn, error: mock.fn() }
+};
+
+const { bulkComplete, getIncompleteTasksByPriority, getAllHouseholdsWithSettings } = require('../../src/services/supabase');
 
 // ─── bulkComplete ─────────────────────────────────────────────────────────────
 
@@ -196,5 +202,58 @@ describe('getIncompleteTasksByPriority', () => {
     assert.equal(tasks[1].id, 'high-fast');
     assert.equal(tasks[2].id, 'high-slow');
     assert.equal(tasks[3].id, 'low');
+  });
+});
+
+// ─── getAllHouseholdsWithSettings ─────────────────────────────────────────────
+
+describe('getAllHouseholdsWithSettings', () => {
+  beforeEach(() => {
+    responseQueue = [];
+    warnFn.mock.resetCalls();
+  });
+
+  it('returns mapped households that have a settings row', async () => {
+    responseQueue.push({
+      data: [{
+        id: 'h1', name: 'Sharma House',
+        settings: [{ calendar_time: '18:00:00', calendar_duration: 60, timezone: 'Asia/Kolkata' }]
+      }],
+      error: null
+    });
+    const result = await getAllHouseholdsWithSettings();
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, 'h1');
+    assert.equal(result[0].settings.calendarTime, '18:00');
+    assert.equal(warnFn.mock.calls.length, 0);
+  });
+
+  it('emits a warning and omits households with no settings row', async () => {
+    responseQueue.push({
+      data: [
+        { id: 'h1', name: 'Sharma House', settings: [] },
+        { id: 'h2', name: 'Kumar House', settings: [{ calendar_time: '19:00:00', calendar_duration: 45, timezone: 'Asia/Kolkata' }] }
+      ],
+      error: null
+    });
+    const result = await getAllHouseholdsWithSettings();
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, 'h2');
+    assert.equal(warnFn.mock.calls.length, 1);
+    assert.equal(warnFn.mock.calls[0].arguments[0], 'household_missing_settings');
+    assert.equal(warnFn.mock.calls[0].arguments[1].householdId, 'h1');
+  });
+
+  it('returns empty array and warns for each household when none have settings', async () => {
+    responseQueue.push({
+      data: [
+        { id: 'h1', name: 'House A', settings: [] },
+        { id: 'h2', name: 'House B', settings: null }
+      ],
+      error: null
+    });
+    const result = await getAllHouseholdsWithSettings();
+    assert.equal(result.length, 0);
+    assert.equal(warnFn.mock.calls.length, 2);
   });
 });


### PR DESCRIPTION
## Summary

- `getAllHouseholdsWithSettings` was silently filtering out any household with no settings row — the scheduler never scheduled it and there was no log entry, making it invisible to operators
- Added `warn("household_missing_settings", { householdId, name })` inside the filter, emitted once per skipped household at bot startup and on every `refreshScheduleForHousehold` call
- `warn` already existed in `logger.js` — the change is two lines: one import, one log call

**Tasks 1 & 2 note:** `npm test` script (`node --test test/`) and CLAUDE.md test docs were already fixed and merged in PR #3 — this branch inherits those.

## Test plan

- [ ] `npm test` passes (218 tests, 0 failures)
- [ ] Household with settings present → no warning emitted, scheduled normally
- [ ] Household with empty/missing settings → `household_missing_settings` warning logged, household excluded from scheduler
- [ ] Multiple households with some missing → one warning per missing household, rest scheduled normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)