### PR TITLE
docs: MVP V1 documentation for users and engineers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# Home OS — Documentation
+
+## For users
+
+| Document | Description |
+|---|---|
+| [Quick Start](users/quick-start.md) | Create or join a household and capture your first task |
+| [Member Guide](users/member-guide.md) | Daily usage: adding tasks, queue, completion, /done, /delete |
+| [Admin Guide](users/admin-guide.md) | Membership management, settings, invite codes |
+
+## For engineers
+
+| Document | Description |
+|---|---|
+| [Architecture](engineering/architecture.md) | System design, data flow, module map, multi-tenancy, scheduler |
+| [Database Schema](engineering/database-schema.md) | All tables, columns, indexes, RLS, recurring task lifecycle |
+| [Commands Reference](engineering/commands-reference.md) | Every bot command with syntax, access level, and examples |
+| [Development Guide](engineering/development.md) | Local setup, test runner, CJS mock pattern, adding commands |
+| [Deployment Guide](engineering/deployment.md) | Railway setup, env vars, DB scripts, health checking |
+
+## Design documents (historical)
+
+| Document | Description |
+|---|---|
+| [PRD](home_os_PRD.md) | Original product requirements |
+| [Execution Plan](home_os_execution_plan.md) | Phase-by-phase build plan |
+| [Multi-Tenant Design](multi-tenant-support.md) | Architecture decision record for multi-household support |
+| [Multi-Household Per User Plan](multi-household-per-user-plan.md) | Future V2 design (not implemented) |
+| [Architecture Overview](home_os_architecture.md) | Early architecture notes |

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -1,0 +1,130 @@
+# Home OS — Architecture
+
+## Overview
+
+Home OS is a multi-tenant Telegram bot: multiple independent families each have their own household with isolated tasks, areas, settings, and cron schedule — all served from a single deployed Node.js process. There is no web frontend, no mobile app, and no push infrastructure beyond the Telegram Bot API.
+
+**Stack:** Node.js 20 · Telegraf · Google Gemini · Supabase (Postgres) · node-cron · Railway
+
+---
+
+## Data flow
+
+```
+Telegram message
+  → Telegraf webhook/polling
+  → householdMiddleware          (upsert user, resolve household membership)
+  → onboarding handlers          (/start, /create, /join — bypass household guard)
+  → admin handlers               (/invite, /members, /promote, /demote, /leavehousehold)
+  → command handlers             (/areas, /queue, /pending, /done, /delete, /settings, …)
+  → message handler              (free text → task capture OR correction)
+      → correction-session       (10-min in-memory TTL)
+      → completion-reply         (2-hr in-memory window)
+      → Gemini classifyTask()    (AI classification)
+      → Supabase createTask()    (persist)
+  → Telegram reply
+```
+
+```
+node-cron (per household)
+  queueJob (at calendarTime, household timezone)
+    → getIncompleteTasksByPriority()
+    → buildQueue()               (greedy fill within calendarDuration)
+    → buildGCalUrl()
+    → sendMessage() to each member
+    → setQueuedTasks()           (in-memory, keyed by member telegramId)
+    → startCompletionWindow()
+
+  completionJob (at calendarTime + calendarDuration + 30 min)
+    → sendMessage() to each member
+```
+
+---
+
+## Key modules
+
+| Module | Responsibility |
+|---|---|
+| `src/bot.js` | Entry point — wires middleware, registers all handlers, starts scheduler |
+| `src/config.js` | Loads and validates required env vars at startup; throws if any are missing |
+| `src/constants.js` | Enums: criticality levels, valid tags, assignee values, default area seed list |
+| `src/middleware/household.js` | Runs on every update: upserts user row, resolves household membership, attaches `ctx.household`, `ctx.householdUser`, `ctx.memberRole` |
+| `src/middleware/guards.js` | `requireMember(handler)` — blocks if no household; `requireAdmin(handler)` — blocks if role is not admin |
+| `src/handlers/onboarding.js` | `/start`, `/create`, `/join` — bypass household guard; handle first contact |
+| `src/handlers/admin.js` | `/invite`, `/members`, `/removemember`, `/promote`, `/demote`, `/leavehousehold` |
+| `src/handlers/commands.js` | `/areas`, `/addarea`, `/removearea`, `/queue`, `/pending`, `/done`, `/delete`, `/settings`, `/settime`, `/setduration`, `/settimezone`, `/help` |
+| `src/handlers/message.js` | Routes free text: correction → completion reply → task capture |
+| `src/handlers/correction.js` | Calls Gemini `correctTask()`, applies patch via `updateTask()`, clears session |
+| `src/handlers/correction-session.js` | In-memory Map keyed by `chatId:userId`; 10-minute TTL per correction session |
+| `src/handlers/complete.js` | Parses completion replies (yes / skip / no / free text); calls `bulkComplete()` |
+| `src/handlers/queue-session.js` | In-memory Maps for queued task lists and 2-hour completion windows; keyed by telegramId |
+| `src/cron/scheduler.js` | `Map<householdId, {queueJob, completionJob}>` — one cron pair per household; `refreshScheduleForHousehold()` called on settings change |
+| `src/services/gemini.js` | `classifyTask(text, areas)` and `correctTask(task, text)` — Gemini API calls with JSON parsing and field normalisation |
+| `src/services/supabase.js` | All DB operations; every function scoped to `householdId`; `bulkComplete` handles recurring vs non-recurring tasks differently |
+| `src/services/queue-builder.js` | Greedy bin-pack: CRITICAL+HIGH always included, then `quick-win`-tagged MEDIUM/LOW up to the duration budget |
+| `src/services/calendar.js` | Builds a Google Calendar TEMPLATE URL for the day's queue |
+| `src/utils/formatters.js` | Telegram message formatters: task card, task-changes diff, queue message |
+| `src/utils/validators.js` | Input sanitisation: effort mins clamping, time/duration/timezone parsing, JSON fence stripping |
+| `src/utils/logger.js` | Structured JSON logger with `info`, `warn`, `error` levels to stdout/stderr |
+
+---
+
+## Multi-tenancy design
+
+Every data table (`tasks`, `areas`, `settings`) carries a `household_id` foreign key. The `householdMiddleware` runs before every handler and attaches the resolved household to `ctx` — handlers never need to look up the household themselves.
+
+**Auth model:**
+- Telegram identity → `users` table (upserted on first contact)
+- `household_members` links users to households with a `role` column (`admin` | `member`)
+- One household per user enforced by `UNIQUE(user_id)` on `household_members`
+- Bot uses the Supabase `service_role` key (bypasses RLS); JWT-scoped mobile policies can be added later using `supabase_auth_user_id` without schema changes
+
+**Invite flow:**
+- Admin generates a single-use 8-char cryptographically random code (via `crypto.randomBytes`)
+- Code stored in `invite_codes` table with 24h expiry
+- `consumeInviteCode()` atomically marks the code used and inserts the membership row; a unique constraint handles the race condition
+
+---
+
+## Scheduler design
+
+Each household gets exactly one pair of cron jobs stored in a `Map<householdId, {queueJob, completionJob}>`. The jobs are created with the household's own `calendarTime` and `timezone` so different families fire at completely independent local times.
+
+`refreshScheduleForHousehold(bot, householdId)` stops the old jobs and creates new ones — called automatically whenever `/settime`, `/setduration`, or `/settimezone` succeeds.
+
+At bot startup, `startScheduler` calls `getAllHouseholdsWithSettings()` and schedules a job pair for every household. Any household without a settings row emits a `warn("household_missing_settings")` log and is skipped.
+
+---
+
+## Gemini integration
+
+Two prompts are used:
+
+- **classifyTask(text, areas)** — structured task extraction. Returns title, area, criticality, effortMins, tags, assignedTo, isRecurring, recurrenceIntervalDays, nextDueDate, reasoning. Fields are normalised after parsing (criticality clamped to enum, effortMins clamped to 1–480, unknown tags filtered out).
+- **correctTask(existingTask, correctionText)** — patch extraction. Returns only the fields the user explicitly changed, leaving others undefined. Applied as a partial update via `updateTask()`.
+
+Both functions strip markdown code fences before parsing and throw a descriptive error if the response is not valid JSON.
+
+---
+
+## In-memory state
+
+Two modules hold transient state (lost on process restart):
+
+| Module | State | TTL |
+|---|---|---|
+| `correction-session.js` | Active correction sessions per user | 10 minutes |
+| `queue-session.js` | Queued task lists and completion windows per user | 2 hours |
+
+This is intentional for MVP: the bot is stateless across restarts for simplicity. If the process restarts during a completion window, users can fall back to `/done <task>` at any time.
+
+---
+
+## External dependencies
+
+| Service | Usage | Auth |
+|---|---|---|
+| Telegram Bot API | Message delivery, webhook/polling | Bot token (`TELEGRAM_BOT_TOKEN`) |
+| Google Gemini | Task classification and correction | API key (`GEMINI_API_KEY`) |
+| Supabase | PostgreSQL database, REST API | Service role key (`SUPABASE_SERVICE_ROLE_KEY`) |
+| Railway | Hosting, auto-deploy from GitHub | Dashboard config |

--- a/docs/engineering/commands-reference.md
+++ b/docs/engineering/commands-reference.md
@@ -1,0 +1,265 @@
+# Home OS — Commands Reference
+
+All commands are available in the private chat with the bot. Commands are case-insensitive.
+
+---
+
+## Onboarding (no household required)
+
+These commands are available before joining a household.
+
+### `/start`
+
+Shows the welcome message if not in a household. If already in one, shows the household name and a pointer to `/help`.
+
+### `/create <name>`
+
+Creates a new household with the caller as admin.
+
+```
+/create The Sharma House
+```
+
+- Name must be 1–60 characters
+- Seeds 12 default areas
+- Creates default settings (18:00, 60 min, Asia/Kolkata)
+- Fails if caller is already in a household
+
+### `/join <code>`
+
+Joins a household using a single-use invite code.
+
+```
+/join K7XP2MNQ
+```
+
+- Code is case-insensitive
+- Fails if code is expired, already used, or invalid
+- Fails if caller is already in a household
+
+---
+
+## Member commands
+
+Available to all members (including admins).
+
+### `/myhousehold`
+
+Shows your household name, your role, total member count, and your join date.
+
+### `/pending`
+
+Lists all incomplete tasks sorted by criticality then effort, numbered for use with `/done` and `/delete`.
+
+```
+🧾 Pending tasks
+
+1. [CRITICAL] Fix bathroom exhaust fan (~30m)
+2. [HIGH] Buy shower curtain (~20m)
+3. [MEDIUM] Deep clean fridge (~45m)
+```
+
+### `/done <number or name>`
+
+Marks a single pending task complete. Supports 1-based index from `/pending` or case-insensitive partial name match.
+
+```
+/done 1
+/done exhaust fan
+```
+
+- Recurring tasks: advances `next_due_date`, keeps the task active
+- Non-recurring tasks: permanently marks `completed = true`
+
+### `/delete <number or name>`
+
+Permanently deletes a pending task. Useful for wrongly captured tasks.
+
+```
+/delete 3
+/delete fridge
+```
+
+### `/queue`
+
+Manually triggers today's queue — same output as the scheduled cron job. Does not affect the cron schedule.
+
+### `/areas`
+
+Lists all household areas alphabetically.
+
+### `/addarea <name>`
+
+Adds a new area to the household.
+
+```
+/addarea Terrace
+```
+
+Duplicate names are silently ignored.
+
+### `/removearea <name>`
+
+Removes an area from the household. Does not affect tasks already tagged with that area.
+
+```
+/removearea Terrace
+```
+
+### `/settings`
+
+Shows the current household settings (read-only for members, editable by admins).
+
+```
+⚙️ The Sharma House
+Time:     18:00
+Duration: 60 mins
+Timezone: Asia/Kolkata
+```
+
+### `/leavehousehold`
+
+Removes you from the household. Tasks remain. If you are the sole admin, you must promote another member first.
+
+### `/help`
+
+Shows all commands available to your role. Admin commands are included only if you are an admin.
+
+---
+
+## Admin commands
+
+### `/invite`
+
+Generates a single-use invite code valid for 24 hours.
+
+```
+🔗 Invite code: K7XP2MNQ
+Expires: 27 Apr 2026, 18:00
+
+→ /join K7XP2MNQ
+```
+
+### `/members`
+
+Lists all household members with their role, join date, and Telegram ID. The Telegram ID is required for `/promote`, `/demote`, and `/removemember`.
+
+```
+👥 The Sharma House — 2 members
+
+1. Navneet (admin) — joined 2025-01-15
+   ID: 123456789
+2. Priya (member) — joined 2025-02-01
+   ID: 987654321
+```
+
+### `/promote <telegram-id>`
+
+Promotes a member to admin.
+
+```
+/promote 987654321
+✅ Priya is now an admin.
+```
+
+### `/demote <telegram-id>`
+
+Demotes an admin to member. Cannot demote yourself if you are the sole admin.
+
+```
+/demote 987654321
+✅ Priya is now a member.
+```
+
+### `/removemember <telegram-id>`
+
+Removes a member from the household. Cannot use this to remove yourself — use `/leavehousehold` instead.
+
+```
+/removemember 987654321
+✅ Priya has been removed from the household.
+```
+
+### `/settime HH:MM`
+
+Sets the time at which the daily queue is sent. Reschedules immediately.
+
+```
+/settime 07:30
+✅ Queue time set to 07:30
+```
+
+### `/setduration <minutes>`
+
+Sets the session duration in minutes (15–480). Affects how many tasks are packed into the queue and when the completion prompt fires.
+
+```
+/setduration 90
+✅ Duration set to 90 mins
+```
+
+### `/settimezone <IANA timezone>`
+
+Sets the timezone for the daily queue and completion prompt. Must be a valid IANA timezone name.
+
+```
+/settimezone Europe/London
+✅ Timezone set to Europe/London
+```
+
+---
+
+## Free-text interactions
+
+### Task capture
+
+Any message that is not a command and does not trigger another flow is treated as a new task.
+
+```
+The kitchen tap is dripping
+```
+
+### Correction
+
+Within 10 minutes of capturing a task, type `correct` or `fix this` to start a correction, then describe the change:
+
+```
+correct
+→ make it HIGH and assign to Professional
+```
+
+Or for the most recently added task, just describe the correction directly:
+
+```
+actually it should be CRITICAL
+```
+
+### Completion replies
+
+During the 2-hour completion window (after the scheduler prompt):
+
+| Input | Effect |
+|---|---|
+| `yes` / `done` / `all done` | All queued tasks marked complete |
+| `skip <name>` | Complete all except the matched task |
+| `no` | Prompts for which tasks were done |
+| `<task name>` | Completes matching tasks (partial name OK) |
+| `<name1>, <name2>` | Completes multiple tasks by partial name |
+
+---
+
+## Allowed values
+
+### Criticality
+
+`CRITICAL` · `HIGH` · `MEDIUM` · `LOW`
+
+### Assignee
+
+`Me` · `Spouse` · `Professional` · `Both`
+
+### Tags
+
+`needs-professional` · `needs-purchase` · `needs-budget` · `kids-related` · `quick-win` · `safety` · `recurring` · `delegated` · `water-damage-risk` · `electrical`
+
+The `quick-win` tag is used by the queue builder to include MEDIUM and LOW tasks in the queue when time allows.

--- a/docs/engineering/database-schema.md
+++ b/docs/engineering/database-schema.md
@@ -1,0 +1,196 @@
+# Home OS — Database Schema
+
+All tables live in a single Supabase (PostgreSQL) project. The bot connects using the `service_role` key, which bypasses Row Level Security. RLS is enabled on all tables in preparation for a future mobile app that will use JWT-scoped policies.
+
+---
+
+## Entity relationships
+
+```
+households
+  ├── household_members (household_id FK)  ←  users (user_id FK)
+  ├── invite_codes      (household_id FK)
+  ├── areas             (household_id FK)
+  ├── settings          (household_id FK, 1:1)
+  └── tasks             (household_id FK)
+```
+
+---
+
+## Table definitions
+
+### `households`
+
+The tenant root. One row per family.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK | `gen_random_uuid()` |
+| `name` | text NOT NULL | Display name, max 60 chars enforced in app |
+| `created_at` | timestamptz | `now()` default |
+| `deleted_at` | timestamptz | NULL — reserved for future soft-delete |
+
+---
+
+### `users`
+
+One row per Telegram identity. Created on first contact with the bot.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK | `gen_random_uuid()` |
+| `telegram_id` | text NOT NULL UNIQUE | Telegram numeric user ID stored as string |
+| `telegram_username` | text | `@handle`, may be null |
+| `display_name` | text | First name from Telegram, may be null |
+| `supabase_auth_user_id` | uuid UNIQUE | NULL — reserved for future mobile auth link |
+| `created_at` | timestamptz | `now()` default |
+| `updated_at` | timestamptz | `now()` default |
+
+**Indexes:** `idx_users_telegram_id ON users (telegram_id)`
+
+---
+
+### `household_members`
+
+Links users to households with a role. Enforces one household per user in v1.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK | |
+| `household_id` | uuid NOT NULL | FK → `households(id)` ON DELETE CASCADE |
+| `user_id` | uuid NOT NULL UNIQUE | FK → `users(id)` ON DELETE CASCADE; UNIQUE enforces one household per user |
+| `role` | `member_role` enum | `'admin'` or `'member'`; default `'member'` |
+| `joined_at` | timestamptz | `now()` default |
+
+**Enum:** `CREATE TYPE member_role AS ENUM ('admin', 'member')`
+
+**Indexes:**
+- `idx_hm_household ON household_members (household_id)`
+- `idx_hm_user ON household_members (user_id)`
+
+---
+
+### `invite_codes`
+
+Single-use invite codes with 24-hour expiry. Stored in DB so a future mobile app can generate/consume them too.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK | |
+| `household_id` | uuid NOT NULL | FK → `households(id)` ON DELETE CASCADE |
+| `code` | text NOT NULL UNIQUE | 8 uppercase alphanumeric chars, `crypto.randomBytes` generated |
+| `created_by` | uuid NOT NULL | FK → `users(id)` |
+| `expires_at` | timestamptz NOT NULL | Set to `now() + 24h` at creation |
+| `used_by` | uuid | FK → `users(id)`; NULL until consumed |
+| `used_at` | timestamptz | NULL until consumed; set atomically on join |
+| `created_at` | timestamptz | `now()` default |
+
+**Uniqueness:** A code is dead once `used_at IS NOT NULL` — enforced by the atomic UPDATE in `consumeInviteCode()`.
+
+**Indexes:**
+- `idx_invite_code ON invite_codes (code) WHERE used_at IS NULL`
+- `idx_invite_household ON invite_codes (household_id)`
+
+---
+
+### `areas`
+
+Household-scoped area list. Name is unique per household, not globally.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK | |
+| `household_id` | uuid NOT NULL | FK → `households(id)` ON DELETE CASCADE |
+| `name` | text NOT NULL | |
+| `created_at` | timestamptz | `now()` default |
+
+**Unique index:** `idx_areas_household_name ON areas (household_id, name)`
+
+---
+
+### `settings`
+
+One row per household. Created with defaults when the household is created.
+
+| Column | Type | Default | Notes |
+|---|---|---|---|
+| `id` | uuid PK | | |
+| `household_id` | uuid NOT NULL UNIQUE | | FK → `households(id)` ON DELETE CASCADE |
+| `calendar_time` | time NOT NULL | `'18:00:00'` | Daily queue fire time (HH:MM:SS) |
+| `calendar_duration` | int NOT NULL | `60` | Session length in minutes (15–480) |
+| `timezone` | text NOT NULL | `'Asia/Kolkata'` | IANA timezone identifier |
+| `permissions` | jsonb NOT NULL | `'{}'` | Reserved for future access control flags |
+| `created_at` | timestamptz | `now()` | |
+
+**Permissions JSONB:** Currently unused. Future example: `{"area_management": "admin_only"}` to restrict area commands to admins only.
+
+---
+
+### `tasks`
+
+The core data table. All queries are scoped to `household_id`.
+
+| Column | Type | Default | Notes |
+|---|---|---|---|
+| `id` | uuid PK | `gen_random_uuid()` | |
+| `household_id` | uuid NOT NULL | | FK → `households(id)` ON DELETE CASCADE |
+| `title` | text NOT NULL | | Human-readable task name |
+| `area` | text NOT NULL | | Matched against `areas.name` |
+| `criticality` | text NOT NULL | | `CRITICAL` / `HIGH` / `MEDIUM` / `LOW` |
+| `effort_mins` | int NOT NULL | `30` | Clamped to 1–480 |
+| `tags` | text[] | `'{}'` | Subset of allowed tag values |
+| `assigned_to` | text | | `Me` / `Spouse` / `Professional` / `Both` |
+| `deadline` | date | NULL | ISO date, optional |
+| `reasoning` | text | NULL | AI explanation shown on task card |
+| `raw_input` | text | NULL | Original user message |
+| `added_by` | text | NULL | `telegram_id` of the user who created the task |
+| `completed` | boolean NOT NULL | `false` | |
+| `completed_at` | timestamptz | NULL | Set when permanently completed |
+| `is_recurring` | boolean NOT NULL | `false` | |
+| `recurrence_interval_days` | int | NULL | Days between occurrences |
+| `next_due_date` | date | NULL | Next time this recurring task should appear |
+| `last_completed_at` | date | NULL | Date of last completion (used to advance next_due_date) |
+| `created_at` | timestamptz | `now()` | |
+
+**Recurring task lifecycle:**
+- Non-recurring: `bulkComplete()` sets `completed = true, completed_at = now`
+- Recurring: `bulkComplete()` sets `last_completed_at = today`, advances `next_due_date += recurrence_interval_days`, leaves `completed = false`
+- `getIncompleteTasksByPriority()` filters recurring tasks to only those where `next_due_date <= today` or `next_due_date IS NULL`
+
+**Indexes:**
+```sql
+CREATE INDEX idx_tasks_household_incomplete
+  ON tasks (household_id, criticality, effort_mins) WHERE completed = false;
+
+CREATE INDEX idx_tasks_household_area
+  ON tasks (household_id, area) WHERE completed = false;
+
+CREATE INDEX idx_tasks_recurring_due
+  ON tasks (household_id, next_due_date)
+  WHERE is_recurring = true AND completed = false;
+```
+
+---
+
+## RLS status
+
+RLS is enabled on all tables. The bot uses the `service_role` key which bypasses all policies. When a mobile app is added, row-level policies using `supabase_auth_user_id` can be applied without any schema changes.
+
+```sql
+ALTER TABLE households        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE users             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE household_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE invite_codes      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE areas             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE settings          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tasks             ENABLE ROW LEVEL SECURITY;
+```
+
+---
+
+## Setup scripts
+
+Run in this order via the Supabase SQL Editor:
+
+1. `scripts/multi_tenant_schema.sql` — creates all tables, types, indexes, RLS
+2. `scripts/migrate_to_multitenant.sql` — one-time backfill for existing deployments (skip for fresh installs)

--- a/docs/engineering/deployment.md
+++ b/docs/engineering/deployment.md
@@ -1,0 +1,122 @@
+# Home OS — Deployment Guide
+
+Home OS is deployed on Railway as a single always-on Node.js process. It uses Telegram long-polling (not webhooks), so no public URL or SSL certificate is required.
+
+---
+
+## Railway setup
+
+### First deployment
+
+1. Push the repository to GitHub.
+2. Go to [railway.app](https://railway.app) → **New Project** → **Deploy from GitHub repo**.
+3. Select the `home-os-bot` repository.
+4. Railway detects Node.js automatically via `package.json` and uses NIXPACKS to build.
+5. The start command is `node src/bot.js` (defined in `railway.toml`).
+
+### Environment variables
+
+Add all required variables in the Railway dashboard under **Variables**:
+
+| Variable | Required | Description |
+|---|---|---|
+| `TELEGRAM_BOT_TOKEN` | Yes | From @BotFather |
+| `GEMINI_API_KEY` | Yes | From aistudio.google.com |
+| `SUPABASE_URL` | Yes | `https://<project>.supabase.co` |
+| `SUPABASE_SERVICE_ROLE_KEY` | Yes | From Supabase → Settings → API (service_role) |
+| `GEMINI_MODEL` | No | Defaults to `gemini-2.5-flash` |
+| `COMPLETION_PROMPT_DELAY_MINS` | No | Defaults to `60` |
+
+The bot will not start and will exit with code 1 if any required variable is missing.
+
+---
+
+## Database setup
+
+Run these scripts once in the **Supabase SQL Editor** before the first deployment:
+
+### Fresh install
+
+```
+scripts/multi_tenant_schema.sql
+```
+
+Creates all tables, enums, indexes, and enables RLS.
+
+### Migrating an existing single-household deployment
+
+```
+scripts/migrate_to_multitenant.sql
+```
+
+Edit the two variables at the top of the script before running:
+- `:seed_household_name` — name for the existing household
+- `:admin_telegram_id` — Telegram ID of the existing admin user
+
+---
+
+## railway.toml
+
+```toml
+[build]
+builder = "NIXPACKS"
+
+[deploy]
+startCommand = "node src/bot.js"
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10
+```
+
+Auto-restarts up to 10 times on failure. If the bot crashes more than 10 times in succession, Railway stops and alerts.
+
+---
+
+## Deploying updates
+
+Push to `main`. Railway detects the push and redeploys automatically.
+
+**Zero-downtime note:** The bot uses long-polling. During the redeploy window (typically 5–15 seconds), Telegram queues incoming messages and delivers them to the new instance. No messages are lost.
+
+---
+
+## Checking health
+
+Railway shows stdout/stderr logs in the dashboard. The bot emits structured JSON on startup:
+
+```json
+{"ts":"2026-04-27T12:00:00Z","level":"info","event":"scheduler_started","householdCount":2}
+{"ts":"2026-04-27T12:00:00Z","level":"info","event":"bot_started"}
+```
+
+If `householdCount` is lower than expected, check for `household_missing_settings` warnings:
+
+```json
+{"ts":"2026-04-27T12:00:00Z","level":"warn","event":"household_missing_settings","householdId":"...","name":"..."}
+```
+
+This means a household exists in the database but has no settings row — it will not be scheduled until the settings row is created (run `upsertSettings` manually or reinitiate via the bot).
+
+---
+
+## Costs
+
+| Service | Tier | Cost |
+|---|---|---|
+| Railway | Hobby | ~$5/month (always-on) |
+| Supabase | Free | 0 (500 MB storage, 2 GB bandwidth) |
+| Gemini API | Free | 0 (1,500 requests/day on free tier) |
+| Telegram | Free | 0 |
+
+For a household with 2–4 members adding a few tasks per day, the Gemini free tier is more than sufficient.
+
+---
+
+## Scaling considerations
+
+The current architecture is single-process. All in-memory state (correction sessions, completion windows) is lost on restart. For higher reliability:
+
+- Migrate session state to Redis or a Supabase table
+- Use Railway's volume mount for persistence
+- Add a health-check endpoint (requires adding a small HTTP server)
+
+These are V2 concerns — the current design handles household-scale load with significant headroom.

--- a/docs/engineering/development.md
+++ b/docs/engineering/development.md
@@ -1,0 +1,160 @@
+# Home OS — Development Guide
+
+## Prerequisites
+
+- Node.js ≥ 20
+- A Supabase project (free tier is sufficient)
+- A Telegram bot token from [@BotFather](https://t.me/BotFather)
+- A Google Gemini API key from [AI Studio](https://aistudio.google.com)
+
+---
+
+## Environment setup
+
+```bash
+cp .env.example .env
+```
+
+Fill in `.env`:
+
+```env
+TELEGRAM_BOT_TOKEN=          # from @BotFather
+GEMINI_API_KEY=              # from aistudio.google.com
+GEMINI_MODEL=                # optional; defaults to gemini-2.5-flash
+SUPABASE_URL=                # https://<project>.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=   # Settings → API → service_role (NOT anon key)
+COMPLETION_PROMPT_DELAY_MINS= # optional; defaults to 60
+```
+
+---
+
+## Database setup
+
+Run these SQL scripts in order via the Supabase SQL Editor:
+
+1. **Fresh install:** `scripts/multi_tenant_schema.sql`
+2. **Existing deployment migration:** also run `scripts/migrate_to_multitenant.sql` (edit the two variable values at the top before running)
+
+---
+
+## Running locally
+
+```bash
+npm install
+npm run dev      # node --watch; restarts on file changes
+```
+
+The bot uses long-polling (not webhooks) so it works without a public URL.
+
+---
+
+## Running tests
+
+```bash
+npm test                                    # all 218 tests
+node --test test/unit/validators.test.js    # single file
+node --test test/handlers/                  # one directory
+```
+
+The test runner is Node's built-in `node:test`. No external test libraries. Output is TAP format.
+
+---
+
+## Test structure
+
+```
+test/
+  unit/
+    validators.test.js        # input normalisation functions
+    formatters.test.js        # Telegram message formatters
+    queue-builder.test.js     # greedy queue algorithm
+    calendar.test.js          # Google Calendar URL builder
+    correction-session.test.js
+    queue-session.test.js
+    supabase.test.js          # bulkComplete, getIncompleteTasksByPriority, getAllHouseholdsWithSettings
+  handlers/
+    complete.test.js          # completion reply parsing
+    correction.test.js        # task correction flow
+    message.test.js           # message routing
+    onboarding.test.js        # /create, /join
+    admin.test.js             # admin commands
+    commands.test.js          # member commands including /done, /delete
+  middleware/
+    household.test.js         # household resolution middleware
+    guards.test.js            # requireMember, requireAdmin
+  cron/
+    scheduler.test.js         # cron job creation and callbacks
+```
+
+---
+
+## Mocking pattern (CJS)
+
+All production modules use CommonJS `require`. Destructured imports bind at load time, so `mock.method()` on an exported object will not intercept calls inside a module that has already imported the function.
+
+**The correct pattern: inject via `require.cache` before requiring the module under test.**
+
+```js
+const { mock } = require('node:test');
+
+// 1. Build the fake module
+const fakeSupabase = {
+  getIncompleteTasksByPriority: mock.fn(async () => []),
+  createTask: mock.fn(async () => 'task-uuid')
+};
+
+// 2. Inject into the cache BEFORE requiring the module under test
+require.cache[require.resolve('../../src/services/supabase')] = {
+  exports: fakeSupabase
+};
+
+// 3. Now require the module — it picks up the fake
+const { handleMessage } = require('../../src/handlers/message');
+```
+
+**Reset between tests:**
+
+```js
+beforeEach(() => {
+  fakeSupabase.createTask.mock.resetCalls();
+  fakeSupabase.createTask.mock.mockImplementation(async () => 'new-id');
+});
+```
+
+**When mocking a module with side effects at load time** (e.g., `supabase.js` creates a client, `config.js` validates env vars), also inject those dependencies before requiring.
+
+---
+
+## Key constants
+
+Defined in `src/constants.js` and used across handlers and the AI prompt:
+
+- **Criticality:** `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`
+- **Assignee:** `Me`, `Spouse`, `Professional`, `Both`
+- **Tags:** `needs-professional`, `needs-purchase`, `needs-budget`, `kids-related`, `quick-win`, `safety`, `recurring`, `delegated`, `water-damage-risk`, `electrical`
+- **Default areas (12):** Kitchen, Bathroom, Common Bathroom, Living Room, Master Bedroom, Guest Bedroom, Office, Garden, Balcony, Utility Room, Entrance, General
+
+---
+
+## Adding a new command
+
+1. Identify the correct handler file: `onboarding.js` (no household required), `admin.js` (admin-only), or `commands.js` (any member).
+2. Register with `bot.command("name", requireMember(async (ctx) => { ... }))` or `requireAdmin(...)`.
+3. Add the command name and description to the `/help` handler in `commands.js`.
+4. Add a test in the corresponding test file using the `buildFakeBot()` / `makeCtx()` helpers.
+
+---
+
+## Logging
+
+`src/utils/logger.js` emits structured JSON lines to stdout/stderr.
+
+```js
+const { info, warn, error } = require('../utils/logger');
+
+info("queue_posted", { householdId, count: 3, audienceCount: 2 });
+warn("household_missing_settings", { householdId, name: "Unnamed" });
+error("task_capture_failed", { message: err.message, userId });
+```
+
+`error` level goes to `console.error`; `info` and `warn` go to `console.log`. Railway captures both streams.

--- a/docs/users/admin-guide.md
+++ b/docs/users/admin-guide.md
@@ -1,0 +1,179 @@
+# Home OS — Admin Guide
+
+As a household admin you can manage membership, configure the daily schedule, and control household areas. Members can add tasks and interact with the queue but cannot change settings or manage other members.
+
+---
+
+## Household settings
+
+### View current settings
+
+```
+/settings
+```
+
+```
+⚙️ The Sharma House
+Time:     18:00
+Duration: 60 mins
+Timezone: Asia/Kolkata
+```
+
+### Set the daily queue time
+
+```
+/settime HH:MM
+```
+
+```
+/settime 07:30
+✅ Queue time set to 07:30
+```
+
+The scheduler reschedules immediately — no restart needed.
+
+### Set session duration
+
+The duration controls how many tasks are packed into the queue (greedy fill) and when the completion prompt fires.
+
+```
+/setduration <minutes>   # 15–480
+```
+
+```
+/setduration 90
+✅ Duration set to 90 mins
+```
+
+### Set timezone
+
+Use any valid IANA timezone name. The queue and completion prompt fire at the correct local time regardless of where the server runs.
+
+```
+/settimezone <IANA name>
+```
+
+```
+/settimezone Europe/London
+✅ Timezone set to Europe/London
+```
+
+Common timezones: `Asia/Kolkata`, `Europe/London`, `America/New_York`, `America/Los_Angeles`, `Asia/Dubai`, `Australia/Sydney`.
+
+---
+
+## Member management
+
+### Generate an invite
+
+Each code is single-use and expires in 24 hours. Generate a fresh one for each person.
+
+```
+/invite
+```
+
+```
+🔗 Invite code: K7XP2MNQ
+Expires: 27 Apr 2026, 18:00
+
+Share this with your family member:
+→ /join K7XP2MNQ
+```
+
+### List members
+
+```
+/members
+```
+
+```
+👥 The Sharma House — 2 members
+
+1. Navneet (admin) — joined 2025-01-15
+   ID: 123456789
+2. Priya (member) — joined 2025-02-01
+   ID: 987654321
+```
+
+The Telegram ID shown next to each member is what you pass to `/promote`, `/demote`, and `/removemember`.
+
+### Promote a member to admin
+
+```
+/promote 987654321
+✅ Priya is now an admin.
+```
+
+### Demote an admin to member
+
+You cannot demote yourself if you are the only admin. Promote someone else first.
+
+```
+/demote 987654321
+✅ Priya is now a member.
+```
+
+### Remove a member
+
+```
+/removemember 987654321
+✅ Priya has been removed from the household.
+```
+
+The member's tasks remain in the household. Only their membership is removed.
+
+### Leave the household
+
+If you are the sole admin, promote another member first.
+
+```
+/leavehousehold
+👋 You've left "The Sharma House".
+```
+
+---
+
+## Area management
+
+Areas appear on every task card and help filter by location. Admins and members can both manage areas by default.
+
+### List areas
+
+```
+/areas
+```
+
+### Add an area
+
+```
+/addarea Terrace
+✅ Added area: Terrace
+```
+
+### Remove an area
+
+```
+/removearea Terrace
+✅ Removed area: Terrace
+```
+
+Removing an area does not affect tasks already tagged with it.
+
+---
+
+## Default areas
+
+These 12 areas are seeded when the household is created:
+
+Kitchen · Bathroom · Common Bathroom · Living Room · Master Bedroom · Guest Bedroom · Office · Garden · Balcony · Utility Room · Entrance · General
+
+---
+
+## How the daily queue works
+
+1. At the scheduled time the bot fetches all incomplete tasks sorted by criticality (CRITICAL → HIGH → MEDIUM → LOW), then by effort (shortest first within each level).
+2. A greedy algorithm fills the session duration: CRITICAL and HIGH tasks are always included; MEDIUM and LOW tasks are included only if tagged `quick-win` and they fit in the remaining time.
+3. The queue is sent as a private message to each member, with a Google Calendar link that blocks the session time.
+4. After `duration + 30 minutes`, the completion prompt fires.
+
+Tasks from recurring items are only included in the queue when their `next_due_date` is today or in the past.

--- a/docs/users/member-guide.md
+++ b/docs/users/member-guide.md
@@ -1,0 +1,180 @@
+# Home OS — Member Guide
+
+Members add tasks, receive the daily queue, confirm completion, and manage their own task list. Settings and membership are managed by admins.
+
+---
+
+## Adding a task
+
+Send any plain-English description in your private chat with the bot. No commands, no forms.
+
+```
+The bathroom exhaust fan is making a grinding noise
+```
+
+```
+📋 Fix bathroom exhaust fan
+📍 Bathroom
+🟡 HIGH  ⏱ 30 mins
+👤 Me
+🏷 needs-professional
+💡 Grinding noise suggests bearing wear — needs inspection before failure
+```
+
+**What the AI infers automatically:**
+- **Area** — matched against your household's area list; new areas are created if needed
+- **Criticality** — CRITICAL / HIGH / MEDIUM / LOW based on urgency and safety
+- **Effort** — estimated minutes
+- **Assignee** — Me / Spouse / Professional / Both
+- **Tags** — from: `needs-professional`, `needs-purchase`, `needs-budget`, `kids-related`, `quick-win`, `safety`, `recurring`, `delegated`, `water-damage-risk`, `electrical`
+- **Recurrence** — if you say "every week" or "monthly", the task is marked recurring
+
+---
+
+## Correcting a task
+
+If the AI got something wrong, reply immediately (within 10 minutes):
+
+```
+make it CRITICAL and assign to Professional
+```
+
+The bot applies only the fields you mentioned. Everything else stays the same. The correction card shows exactly what changed.
+
+Alternatively, type `correct` or `fix this` to start a correction on your most recently captured task.
+
+---
+
+## Viewing pending tasks
+
+```
+/pending
+```
+
+```
+🏠 The Sharma House
+
+🧾 Pending tasks
+
+1. [CRITICAL] Fix bathroom exhaust fan (~30m)
+2. [HIGH] Buy new shower curtain (~20m)
+3. [MEDIUM] Deep clean fridge (~45m)
+```
+
+Tasks are sorted by criticality first, then by effort (shorter tasks first within the same level).
+
+---
+
+## Marking tasks complete
+
+### By number (from /pending list)
+
+```
+/done 1
+✅ Marked done: Fix bathroom exhaust fan
+```
+
+### By name (partial match works)
+
+```
+/done exhaust fan
+✅ Marked done: Fix bathroom exhaust fan
+```
+
+### Recurring tasks
+
+Completing a recurring task advances its `next_due_date` forward by the recurrence interval and keeps it active — it re-appears in the queue automatically when due again.
+
+---
+
+## Deleting a task
+
+Use `/delete` to permanently remove a task that was captured incorrectly.
+
+```
+/delete 3
+🗑️ Deleted: Deep clean fridge
+```
+
+```
+/delete fridge
+🗑️ Deleted: Deep clean fridge
+```
+
+---
+
+## The daily queue
+
+At your household's configured time, the bot sends a private message with today's prioritised task list and a Google Calendar link.
+
+```
+🏠 The Sharma House
+
+📅 Today's queue (2 tasks · 50 mins · 10 min buffer)
+
+1. [CRITICAL] Fix bathroom exhaust fan — 30 min
+2. [HIGH] Buy new shower curtain — 20 min
+
+→ https://calendar.google.com/...
+```
+
+Tap the Calendar link to create a timed event in your calendar with all the tasks in the description.
+
+---
+
+## Completing the queue
+
+About 30 minutes after your session ends, the bot prompts:
+
+```
+⏰ Your block just ended. Done? Reply yes / skip <task> / no
+```
+
+**Reply options:**
+
+| Reply | Effect |
+|---|---|
+| `yes` | All queued tasks marked complete |
+| `done` | Same as yes |
+| `all done` | Same as yes |
+| `skip exhaust fan` | Completes all except the matched task |
+| `no` | Bot asks which ones you finished; reply with names |
+| `exhaust fan, shower curtain` | Marks only those two tasks complete |
+| `exhaust` | Partial name match — marks the exhaust fan task complete |
+
+If you miss the 2-hour window, use `/done` at any time.
+
+---
+
+## Household info
+
+```
+/myhousehold
+```
+
+```
+🏠 The Sharma House
+Your role: member
+Members:   2
+Joined:    2025-02-01
+```
+
+---
+
+## Getting help
+
+```
+/help
+```
+
+Shows all commands available to you based on your role. Admin commands are only shown if you are an admin.
+
+---
+
+## Leaving the household
+
+```
+/leavehousehold
+```
+
+Your tasks remain in the household. If you want to rejoin later, ask your admin for a new invite code.

--- a/docs/users/quick-start.md
+++ b/docs/users/quick-start.md
@@ -1,0 +1,132 @@
+# Home OS — Quick Start Guide
+
+Home OS is a Telegram bot that captures household tasks in plain language, prioritises them by urgency, and delivers a time-boxed daily work queue straight to your phone. No app install. No logins. Just message the bot.
+
+---
+
+## Prerequisites
+
+- A Telegram account (mobile or desktop)
+- The bot username from your household admin (or from whoever set it up)
+
+---
+
+## Path A — Starting a new household (you are the admin)
+
+### 1. Start the bot
+
+Open a private chat with the bot and send:
+
+```
+/start
+```
+
+You will see the welcome message with two options.
+
+### 2. Create your household
+
+```
+/create The Sharma House
+```
+
+- Name can be up to 60 characters
+- You become the admin automatically
+- Default areas (Kitchen, Bathroom, Living Room, etc.) are seeded
+- Default settings: queue at 18:00, 60-minute session, Asia/Kolkata timezone
+
+### 3. Invite your family
+
+```
+/invite
+```
+
+The bot sends you a single-use 8-character code valid for 24 hours:
+
+```
+🔗 Invite code: K7XP2MNQ
+Expires: 27 Apr 2026, 18:00
+
+Share this with your family member:
+→ /join K7XP2MNQ
+```
+
+Share that `/join` line with each person you want to add.
+
+---
+
+## Path B — Joining an existing household
+
+### 1. Start the bot
+
+```
+/start
+```
+
+### 2. Join with the invite code your admin shared
+
+```
+/join K7XP2MNQ
+```
+
+Once joined, you are a **member** with full task access. Your admin manages settings and membership.
+
+---
+
+## Your first task
+
+Just send a message in plain English — no commands needed:
+
+```
+Kitchen tap is leaking badly
+```
+
+The bot replies with a structured task card:
+
+```
+🏠 The Sharma House
+
+📋 Fix kitchen tap leak
+📍 Kitchen
+🔴 CRITICAL  ⏱ 45 mins
+👤 Me
+🏷 water-damage-risk, safety
+💡 Urgent plumbing issue — water damage risk if left unattended
+```
+
+If the AI picks up anything wrong, reply immediately:
+
+```
+make it HIGH, assign to Professional
+```
+
+The bot corrects only the fields you mentioned and confirms the change.
+
+---
+
+## The daily routine
+
+1. **At your set queue time** the bot sends a prioritised task list to each member privately, with a Google Calendar link you can tap to block the time.
+
+2. **After your session ends** the bot prompts:
+   ```
+   ⏰ Your block just ended. Done? Reply yes / skip <task> / no
+   ```
+
+3. **Reply naturally:**
+   - `yes` — marks everything complete
+   - `skip kitchen tap` — completes all except that one
+   - `no` — bot asks which ones you finished; reply with names or use `/done`
+   - `fix kitchen tap, mow lawn` — completes just those two
+
+---
+
+## Most useful commands at a glance
+
+| Command | What it does |
+|---|---|
+| `/pending` | See all tasks, numbered |
+| `/done 2` | Mark task #2 complete |
+| `/done fix tap` | Mark by name (partial match works) |
+| `/delete 3` | Delete a wrongly captured task |
+| `/queue` | Manually trigger today's queue |
+| `/help` | Full command list |


### PR DESCRIPTION
## Summary

Adds professional documentation for all personas, segregated into two directories.

### `docs/users/`
- **quick-start.md** — create or join a household, first task, daily routine overview
- **member-guide.md** — full daily usage guide: task capture, correction, queue, `/done`, `/delete`, completion flow variants
- **admin-guide.md** — settings management, invite codes, member lifecycle (promote/demote/remove), area management

### `docs/engineering/`
- **architecture.md** — system design, data flow diagram, module responsibility table, multi-tenancy model, scheduler design, Gemini integration, in-memory state policy, external dependencies
- **database-schema.md** — every table with column types, defaults, constraints, indexes, RLS status, and recurring task lifecycle explanation
- **commands-reference.md** — every bot command with syntax, access level, response format, examples, and all allowed enum values
- **development.md** — local setup, test runner, CJS mock pattern (the `require.cache` injection technique), adding new commands, logging
- **deployment.md** — Railway setup, env vars table, DB script order, `railway.toml` config, health checking, cost breakdown, scaling notes

### `docs/README.md`
- Index linking all new docs plus the existing historical design documents

## MVP V1 audit result

All core features are implemented. The recurring task engine (auto-regeneration cron) is correctly deferred to V2 per the original PRD scope. The "queue session keying mismatch" flagged by static analysis is not a bug — for private chats `ctx.chat.id === user's telegramId` and `queue-session.js` normalises both with `String()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)