### PR TITLE
feat: JARVIS witty confirmations via Gemini

### DIFF
--- a/scripts/test-witty-responses.js
+++ b/scripts/test-witty-responses.js
@@ -1,0 +1,41 @@
+require("dotenv").config();
+const { generateWittyReply } = require("../src/services/witty-response");
+
+const scenarios = [
+  { label: "task_added",        action: "task_added",        ctx: { title: "Fix kitchen tap leak", area: "Kitchen", assignedTo: "Me" } },
+  { label: "task_corrected",    action: "task_corrected",    ctx: { title: "Fix kitchen tap leak" } },
+  { label: "task_completed",    action: "task_completed",    ctx: { title: "Mow the lawn" } },
+  { label: "tasks_all_done x4", action: "tasks_all_done",    ctx: { count: 4 } },
+  { label: "tasks_all_done x1", action: "tasks_all_done",    ctx: { count: 1 } },
+  { label: "tasks_partial",     action: "tasks_partial",     ctx: { count: 3, skippedName: "Deep clean fridge" } },
+  { label: "task_deleted",      action: "task_deleted",      ctx: { title: "Buy milk" } },
+  { label: "area_added",        action: "area_added",        ctx: { name: "Terrace" } },
+  { label: "area_removed",      action: "area_removed",      ctx: { name: "Guest Bedroom" } },
+  { label: "time_set",          action: "time_set",          ctx: { time: "07:30" } },
+  { label: "duration_set",      action: "duration_set",      ctx: { mins: 90 } },
+  { label: "timezone_set",      action: "timezone_set",      ctx: { tz: "Europe/London" } },
+  { label: "household_created", action: "household_created", ctx: { name: "The Sharma House" } },
+  { label: "household_joined",  action: "household_joined",  ctx: { name: "The Sharma House" } },
+  { label: "invite_generated",  action: "invite_generated",  ctx: { code: "K7XP2MNQ" } },
+  { label: "member_removed",    action: "member_removed",    ctx: { name: "Priya" } },
+  { label: "member_promoted",   action: "member_promoted",   ctx: { name: "Priya" } },
+  { label: "member_demoted",    action: "member_demoted",    ctx: { name: "Rahul" } },
+  { label: "left_household",    action: "left_household",    ctx: { name: "The Sharma House" } },
+  { label: "UNKNOWN ACTION",    action: "nonexistent_action", ctx: {} },
+];
+
+async function run() {
+  console.log("=== JARVIS witty response test ===\n");
+  for (const { label, action, ctx } of scenarios) {
+    process.stdout.write(`[${label}]\n  → `);
+    const reply = await generateWittyReply(action, ctx);
+    console.log(reply === null ? "null — fallback (expected for unknown actions)" : reply);
+    console.log();
+  }
+  console.log("=== Done ===");
+}
+
+run().catch((err) => {
+  console.error("Script failed:", err.message);
+  process.exit(1);
+});

--- a/src/handlers/admin.js
+++ b/src/handlers/admin.js
@@ -7,6 +7,7 @@ const {
   updateMemberRole
 } = require("../services/supabase");
 const { requireAdmin, requireMember } = require("../middleware/guards");
+const { generateWittyReply } = require("../services/witty-response");
 
 function formatJoinedDate(isoString) {
   return new Date(isoString).toISOString().slice(0, 10);
@@ -38,11 +39,9 @@ function registerAdminCommands(bot) {
   bot.command("invite", requireAdmin(async (ctx) => {
     const { code, expiresAt } = await createInviteCode(ctx.household.id, ctx.householdUser.id);
     const expiryDate = new Date(expiresAt).toLocaleString("en-GB", { dateStyle: "medium", timeStyle: "short" });
-    await ctx.reply(
-      `🔗 Invite code: ${code}\n` +
-      `Expires: ${expiryDate}\n\n` +
-      `Share this with your family member:\n→ /join ${code}`
-    );
+    const inviteBlock = `🔗 Invite code: ${code}\nExpires: ${expiryDate}\n\nShare this with your family member:\n→ /join ${code}`;
+    const witty = await generateWittyReply('invite_generated', { code });
+    await ctx.reply(witty ? `${inviteBlock}\n\n${witty}` : inviteBlock);
   }));
 
   bot.command("members", requireAdmin(async (ctx) => {
@@ -65,7 +64,8 @@ function registerAdminCommands(bot) {
     }
 
     await removeMember(ctx.household.id, targetMember.userId);
-    await ctx.reply(`✅ ${targetMember.displayName} has been removed from the household.`);
+    const witty = await generateWittyReply('member_removed', { name: targetMember.displayName });
+    await ctx.reply(witty || `✅ ${targetMember.displayName} has been removed from the household.`);
   }));
 
   bot.command("promote", requireAdmin(async (ctx) => {
@@ -78,7 +78,8 @@ function registerAdminCommands(bot) {
     }
 
     await updateMemberRole(ctx.household.id, targetMember.userId, "admin");
-    await ctx.reply(`✅ ${targetMember.displayName} is now an admin.`);
+    const witty = await generateWittyReply('member_promoted', { name: targetMember.displayName });
+    await ctx.reply(witty || `✅ ${targetMember.displayName} is now an admin.`);
   }));
 
   bot.command("demote", requireAdmin(async (ctx) => {
@@ -98,7 +99,8 @@ function registerAdminCommands(bot) {
     }
 
     await updateMemberRole(ctx.household.id, targetMember.userId, "member");
-    await ctx.reply(`✅ ${targetMember.displayName} is now a member.`);
+    const witty = await generateWittyReply('member_demoted', { name: targetMember.displayName });
+    await ctx.reply(witty || `✅ ${targetMember.displayName} is now a member.`);
   }));
 
   bot.command("leavehousehold", requireMember(async (ctx) => {
@@ -116,10 +118,9 @@ function registerAdminCommands(bot) {
     }
 
     await removeMember(ctx.household.id, ctx.householdUser.id);
-    await ctx.reply(
-      `👋 You've left "${ctx.household.name}".\n\n` +
-      "Use /create or /join to set up a new household."
-    );
+    const witty = await generateWittyReply('left_household', { name: ctx.household.name });
+    await ctx.reply(witty || `👋 You've left "${ctx.household.name}".`);
+    await ctx.reply("Use /create or /join to set up a new household.");
   }));
 }
 

--- a/src/handlers/commands.js
+++ b/src/handlers/commands.js
@@ -17,6 +17,7 @@ const { requireAdmin, requireMember } = require("../middleware/guards");
 const { formatQueueMessage } = require("../utils/formatters");
 const { parseDurationMinutes, parseTimeHHMM, parseTimezone } = require("../utils/validators");
 const { error } = require("../utils/logger");
+const { generateWittyReply } = require("../services/witty-response");
 
 function householdHeader(name) {
   return `🏠 ${name}\n\n`;
@@ -54,14 +55,16 @@ async function registerCommands(bot) {
     const name = ctx.message.text.replace(/^\/addarea\s*/i, "").trim();
     if (!name) return ctx.reply("Usage: /addarea <name>");
     await addArea(ctx.household.id, name);
-    return ctx.reply(`✅ Added area: ${name}`);
+    const witty = await generateWittyReply('area_added', { name });
+    return ctx.reply(witty || `✅ Added area: ${name}`);
   }));
 
   bot.command("removearea", requireMember(async (ctx) => {
     const name = ctx.message.text.replace(/^\/removearea\s*/i, "").trim();
     if (!name) return ctx.reply("Usage: /removearea <name>");
     await removeArea(ctx.household.id, name);
-    return ctx.reply(`✅ Removed area: ${name}`);
+    const witty = await generateWittyReply('area_removed', { name });
+    return ctx.reply(witty || `✅ Removed area: ${name}`);
   }));
 
   bot.command("queue", requireMember(async (ctx) => {
@@ -90,7 +93,8 @@ async function registerCommands(bot) {
     const task = findTaskByQuery(tasks, query);
     if (!task) return ctx.reply("❌ Task not found. Use /pending to see the list.");
     await bulkComplete([task.id]);
-    return ctx.reply(`✅ Marked done: ${task.title}`);
+    const witty = await generateWittyReply('task_completed', { title: task.title });
+    return ctx.reply(witty || `✅ Marked done: ${task.title}`);
   }));
 
   bot.command("delete", requireMember(async (ctx) => {
@@ -100,7 +104,8 @@ async function registerCommands(bot) {
     const task = findTaskByQuery(tasks, query);
     if (!task) return ctx.reply("❌ Task not found. Use /pending to see the list.");
     await deleteTask(task.id);
-    return ctx.reply(`🗑️ Deleted: ${task.title}`);
+    const witty = await generateWittyReply('task_deleted', { title: task.title });
+    return ctx.reply(witty || `🗑️ Deleted: ${task.title}`);
   }));
 
   bot.command("settings", requireMember(async (ctx) => {
@@ -121,7 +126,8 @@ async function registerCommands(bot) {
     refreshScheduleForHousehold(bot, ctx.household.id).catch((err) =>
       error("scheduler_refresh_failed", { householdId: ctx.household.id, message: err.message })
     );
-    await ctx.reply(`✅ Queue time set to ${parsed}`);
+    const witty = await generateWittyReply('time_set', { time: parsed });
+    await ctx.reply(witty || `✅ Queue time set to ${parsed}`);
   }));
 
   bot.command("setduration", requireAdmin(async (ctx) => {
@@ -132,7 +138,8 @@ async function registerCommands(bot) {
     refreshScheduleForHousehold(bot, ctx.household.id).catch((err) =>
       error("scheduler_refresh_failed", { householdId: ctx.household.id, message: err.message })
     );
-    await ctx.reply(`✅ Duration set to ${parsed} mins`);
+    const witty = await generateWittyReply('duration_set', { mins: parsed });
+    await ctx.reply(witty || `✅ Duration set to ${parsed} mins`);
   }));
 
   bot.command("settimezone", requireAdmin(async (ctx) => {
@@ -143,7 +150,8 @@ async function registerCommands(bot) {
     refreshScheduleForHousehold(bot, ctx.household.id).catch((err) =>
       error("scheduler_refresh_failed", { householdId: ctx.household.id, message: err.message })
     );
-    await ctx.reply(`✅ Timezone set to ${tz}`);
+    const witty = await generateWittyReply('timezone_set', { tz });
+    await ctx.reply(witty || `✅ Timezone set to ${tz}`);
   }));
 
   bot.command("help", requireMember(async (ctx) => {

--- a/src/handlers/complete.js
+++ b/src/handlers/complete.js
@@ -1,5 +1,6 @@
 const { bulkComplete } = require("../services/supabase");
 const { endCompletionWindow, getQueuedTasks } = require("./queue-session");
+const { generateWittyReply } = require("../services/witty-response");
 
 function normalizeText(value) {
   return String(value || "").trim().toLowerCase();
@@ -13,7 +14,8 @@ async function handleCompletionReply(ctx) {
   if (["yes", "done", "all done"].includes(text)) {
     const count = await bulkComplete(queued.map((task) => task.id));
     endCompletionWindow(ctx.chat.id);
-    await ctx.reply(`✅ Marked ${count} tasks as complete.`);
+    const witty = await generateWittyReply('tasks_all_done', { count });
+    await ctx.reply(witty || `✅ Marked ${count} tasks as complete.`);
     return true;
   }
 
@@ -23,7 +25,10 @@ async function handleCompletionReply(ctx) {
     const ids = queued.filter((task) => !skipTask || task.id !== skipTask.id).map((task) => task.id);
     const count = await bulkComplete(ids);
     endCompletionWindow(ctx.chat.id);
-    await ctx.reply(`✅ Completed ${count} tasks. Skipped ${skipTask ? skipTask.title : "none"}.`);
+    const witty = skipTask
+      ? await generateWittyReply('tasks_partial', { count, skippedName: skipTask.title })
+      : await generateWittyReply('tasks_all_done', { count });
+    await ctx.reply(witty || `✅ Completed ${count} tasks. Skipped ${skipTask ? skipTask.title : "none"}.`);
     return true;
   }
 
@@ -43,7 +48,8 @@ async function handleCompletionReply(ctx) {
   if (matches.length > 0) {
     const count = await bulkComplete(matches.map((task) => task.id));
     endCompletionWindow(ctx.chat.id);
-    await ctx.reply(`✅ Marked ${count} selected tasks complete.`);
+    const witty = await generateWittyReply('tasks_all_done', { count });
+    await ctx.reply(witty || `✅ Marked ${count} selected tasks complete.`);
     return true;
   }
 

--- a/src/handlers/correction.js
+++ b/src/handlers/correction.js
@@ -2,13 +2,16 @@ const { correctTask } = require("../services/gemini");
 const { updateTask } = require("../services/supabase");
 const { formatTaskChanges } = require("../utils/formatters");
 const { clearSession } = require("./correction-session");
+const { generateWittyReply } = require("../services/witty-response");
 
 async function handleCorrection(ctx, session) {
   const correctionText = ctx.message.text.trim();
   const patch = await correctTask(session.task, correctionText);
   await updateTask(session.task.id, patch);
   clearSession(ctx.chat.id, ctx.from.id);
-  await ctx.reply(formatTaskChanges(session.task, patch));
+  const changes = formatTaskChanges(session.task, patch);
+  const witty = await generateWittyReply('task_corrected', { title: session.task.title });
+  await ctx.reply(witty ? `${changes}\n\n${witty}` : changes);
 }
 
 module.exports = {

--- a/src/handlers/message.js
+++ b/src/handlers/message.js
@@ -1,4 +1,5 @@
 const { classifyTask } = require("../services/gemini");
+const { generateWittyReply } = require("../services/witty-response");
 const { addArea, createTask, getAreas } = require("../services/supabase");
 const { formatTaskCard } = require("../utils/formatters");
 const { error } = require("../utils/logger");
@@ -50,7 +51,9 @@ async function handleMessage(ctx) {
       await ctx.reply(`🆕 Added "${task.area}" as a new area.`);
     }
 
-    await ctx.reply(`🏠 ${ctx.household.name}\n\n${formatTaskCard({ ...task, id: taskId })}`);
+    const block = `🏠 ${ctx.household.name}\n\n${formatTaskCard({ ...task, id: taskId })}`;
+    const witty = await generateWittyReply('task_added', { title: task.title, area: task.area, assignedTo: task.assignedTo });
+    await ctx.reply(witty ? `${block}\n\n${witty}` : block);
     setRecentTask(ctx.chat.id, ctx.from.id, { ...task, id: taskId });
   } catch (err) {
     error("task_capture_failed", { message: err.message, userId, householdId: ctx.household.id });

--- a/src/handlers/onboarding.js
+++ b/src/handlers/onboarding.js
@@ -1,4 +1,5 @@
 const { createHousehold, consumeInviteCode } = require("../services/supabase");
+const { generateWittyReply } = require("../services/witty-response");
 
 function registerOnboardingCommands(bot) {
   bot.command("start", async (ctx) => {
@@ -26,11 +27,9 @@ function registerOnboardingCommands(bot) {
     if (name.length > 60) return ctx.reply("❌ Household name must be 60 characters or fewer.");
 
     const household = await createHousehold(name, ctx.householdUser.id);
-    await ctx.reply(
-      `🏠 "${household.name}" created! You're the admin.\n\n` +
-      "Default areas and settings are ready.\n" +
-      "Invite your family: /invite"
-    );
+    const createBlock = `🏠 "${household.name}" created! You're the admin.\n\nDefault areas and settings are ready.\nInvite your family: /invite`;
+    const witty = await generateWittyReply('household_created', { name: household.name });
+    await ctx.reply(witty ? `${createBlock}\n\n${witty}` : createBlock);
   });
 
   bot.command("join", async (ctx) => {
@@ -58,10 +57,9 @@ function registerOnboardingCommands(bot) {
       );
     }
 
-    await ctx.reply(
-      `🏠 You've joined "${result.householdName}"! Welcome.\n\n` +
-      "Type naturally to add tasks, or use /help for all commands."
-    );
+    const joinBlock = `🏠 You've joined "${result.householdName}"! Welcome.\n\nType naturally to add tasks, or use /help for all commands.`;
+    const witty = await generateWittyReply('household_joined', { name: result.householdName });
+    await ctx.reply(witty ? `${joinBlock}\n\n${witty}` : joinBlock);
   });
 }
 

--- a/src/services/witty-response.js
+++ b/src/services/witty-response.js
@@ -1,0 +1,70 @@
+const { GoogleGenAI } = require("@google/genai");
+const { config } = require("../config");
+const { warn } = require("../utils/logger");
+
+const client = new GoogleGenAI({ apiKey: config.geminiApiKey });
+
+const SYSTEM_PROMPT = `You are JARVIS, the dry-witted British AI butler from Iron Man, \
+now repurposed to manage domestic tasks for a household.
+You confirm household management actions with short, understated British wit.
+Rules:
+- Maximum 1-2 sentences. Never more.
+- No emojis whatsoever.
+- No markdown formatting (no bold, no bullets, no asterisks).
+- Occasionally address the user as "Sir" or "Ma'am" — not every time.
+- This is household chores, not world-saving — let that contrast amuse you, subtly.
+- The action is confirmed; the wit is incidental. Never be unhelpfully sarcastic.
+- Vary your phrasing. Do not repeat the same sentence structure twice.
+- Reference the specific details of the action naturally.`;
+
+const ACTION_DESCRIPTIONS = {
+  task_added:        (c) => `A new task has been added: '${c.title}' in the ${c.area} area, assigned to ${c.assignedTo}.`,
+  task_corrected:    (c) => `The task '${c.title}' has been updated with corrections.`,
+  task_completed:    (c) => `The task '${c.title}' has been marked complete.`,
+  tasks_all_done:    (c) => `${c.count} task${c.count !== 1 ? "s" : ""} have been marked complete.`,
+  tasks_partial:     (c) => `${c.count} tasks completed; '${c.skippedName}' was intentionally skipped.`,
+  task_deleted:      (c) => `The task '${c.title}' has been permanently deleted.`,
+  area_added:        (c) => `A new household area called '${c.name}' has been added.`,
+  area_removed:      (c) => `The area '${c.name}' has been removed from the household.`,
+  time_set:          (c) => `The daily queue time has been set to ${c.time}.`,
+  duration_set:      (c) => `The session duration has been set to ${c.mins} minutes.`,
+  timezone_set:      (c) => `The timezone has been set to ${c.tz}.`,
+  household_created: (c) => `A new household called '${c.name}' has been created.`,
+  household_joined:  (c) => `The user has joined the household '${c.name}'.`,
+  invite_generated:  (c) => `An invite code has been generated: ${c.code}.`,
+  member_removed:    (c) => `${c.name} has been removed from the household.`,
+  member_promoted:   (c) => `${c.name} has been promoted to household admin.`,
+  member_demoted:    (c) => `${c.name} has been demoted from admin to member.`,
+  left_household:    (c) => `The user has left the household '${c.name}'.`,
+};
+
+function sanitizeReply(text) {
+  const cleaned = text.replace(/\n+/g, " ").trim().slice(0, 300);
+  return `✅ ${cleaned}`;
+}
+
+async function generateText(prompt) {
+  const response = await client.models.generateContent({
+    model: config.geminiModel,
+    contents: prompt
+  });
+  const text = (response.text || "").trim();
+  if (!text) throw new Error("Gemini returned empty response.");
+  return text;
+}
+
+async function generateWittyReply(action, context = {}) {
+  try {
+    const descFn = ACTION_DESCRIPTIONS[action];
+    if (!descFn) return null;
+    const actionDescription = descFn(context);
+    const prompt = `${SYSTEM_PROMPT}\n\nConfirm the following household action with a JARVIS-style witty remark:\n${actionDescription}`;
+    const raw = await generateText(prompt);
+    return sanitizeReply(raw);
+  } catch (err) {
+    warn("witty_reply_failed", { action, message: err.message });
+    return null;
+  }
+}
+
+module.exports = { generateWittyReply };

--- a/test/handlers/admin.test.js
+++ b/test/handlers/admin.test.js
@@ -12,6 +12,9 @@ const updateMemberRole = mock.fn(async () => {});
 require.cache[require.resolve('../../src/services/supabase')] = {
   exports: { createInviteCode, findUserByTelegramId, getAdminCount, getHouseholdMembers, removeMember, updateMemberRole }
 };
+require.cache[require.resolve('../../src/services/witty-response')] = {
+  exports: { generateWittyReply: mock.fn(async () => null) }
+};
 // guards.js has no external deps — let it run natively
 delete require.cache[require.resolve('../../src/middleware/guards')];
 

--- a/test/handlers/commands.test.js
+++ b/test/handlers/commands.test.js
@@ -21,6 +21,9 @@ require.cache[require.resolve('../../src/services/supabase')] = {
 require.cache[require.resolve('../../src/cron/scheduler')] = {
   exports: { refreshScheduleForHousehold }
 };
+require.cache[require.resolve('../../src/services/witty-response')] = {
+  exports: { generateWittyReply: mock.fn(async () => null) }
+};
 // guards and validators have no external deps — let them run natively
 delete require.cache[require.resolve('../../src/middleware/guards')];
 delete require.cache[require.resolve('../../src/utils/validators')];

--- a/test/handlers/complete.test.js
+++ b/test/handlers/complete.test.js
@@ -12,6 +12,9 @@ require.cache[require.resolve('../../src/services/supabase')] = {
 require.cache[require.resolve('../../src/handlers/queue-session')] = {
   exports: { getQueuedTasks, endCompletionWindow }
 };
+require.cache[require.resolve('../../src/services/witty-response')] = {
+  exports: { generateWittyReply: mock.fn(async () => null) }
+};
 
 const { handleCompletionReply } = require('../../src/handlers/complete');
 

--- a/test/handlers/correction.test.js
+++ b/test/handlers/correction.test.js
@@ -15,6 +15,9 @@ require.cache[require.resolve('../../src/services/supabase')] = {
 require.cache[require.resolve('../../src/handlers/correction-session')] = {
   exports: { clearSession }
 };
+require.cache[require.resolve('../../src/services/witty-response')] = {
+  exports: { generateWittyReply: mock.fn(async () => null) }
+};
 
 const { handleCorrection } = require('../../src/handlers/correction');
 

--- a/test/handlers/message.test.js
+++ b/test/handlers/message.test.js
@@ -43,6 +43,9 @@ require.cache[require.resolve('../../src/handlers/complete')] = {
 require.cache[require.resolve('../../src/handlers/queue-session')] = {
   exports: { isCompletionWindowActive }
 };
+require.cache[require.resolve('../../src/services/witty-response')] = {
+  exports: { generateWittyReply: mock.fn(async () => null) }
+};
 
 const { handleMessage } = require('../../src/handlers/message');
 

--- a/test/handlers/onboarding.test.js
+++ b/test/handlers/onboarding.test.js
@@ -8,6 +8,9 @@ const consumeInviteCode = mock.fn(async () => null);
 require.cache[require.resolve('../../src/services/supabase')] = {
   exports: { createHousehold, consumeInviteCode }
 };
+require.cache[require.resolve('../../src/services/witty-response')] = {
+  exports: { generateWittyReply: mock.fn(async () => null) }
+};
 
 const { registerOnboardingCommands } = require('../../src/handlers/onboarding');
 


### PR DESCRIPTION
## Summary

- Adds `src/services/witty-response.js` — a Gemini-powered service that generates dry, British JARVIS-style one-liners for 18 action types
- Every successful bot action now replies with `✅ <JARVIS quip>` instead of a static confirmation
- Falls back silently to the original static message if Gemini is unavailable (rate limit, bad key, etc.) — no crashes, no hangs
- Error messages and guard rejections are deliberately left untouched — JARVIS only speaks on success
- Structured replies (task card, invite block, correction diff) get the JARVIS line appended; pure confirmations replace the static text
- Adds `scripts/test-witty-responses.js` for reviewing persona output without touching the bot

## Test plan

- [x] All 218 existing tests pass with the witty-response module stubbed to return `null` in all 6 handler test files
- [x] Ran `node scripts/test-witty-responses.js` manually — reviewed JARVIS personality and approved
- [ ] Smoke test in Telegram: `/done 1` → `✅ <JARVIS quip>`; set `GEMINI_API_KEY=bad` → `/delete 1` → static fallback with no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)