### PR TITLE
feat: /edit command — modify any pending task by number or name

### DIFF
--- a/src/handlers/commands.js
+++ b/src/handlers/commands.js
@@ -18,6 +18,7 @@ const { formatQueueMessage } = require("../utils/formatters");
 const { parseDurationMinutes, parseTimeHHMM, parseTimezone } = require("../utils/validators");
 const { error } = require("../utils/logger");
 const { generateWittyReply } = require("../services/witty-response");
+const { startSessionForTask } = require("./correction-session");
 
 function householdHeader(name) {
   return `🏠 ${name}\n\n`;
@@ -108,6 +109,20 @@ async function registerCommands(bot) {
     return ctx.reply(witty || `🗑️ Deleted: ${task.title}`);
   }));
 
+  bot.command("edit", requireMember(async (ctx) => {
+    const query = ctx.message.text.replace(/^\/edit\s*/i, "").trim();
+    if (!query) return ctx.reply("Usage: /edit <number or task name>\nExample: /edit 3");
+    const tasks = await getIncompleteTasksByPriority(ctx.household.id);
+    const task = findTaskByQuery(tasks, query);
+    if (!task) return ctx.reply("❌ Task not found. Use /pending to see the list.");
+    startSessionForTask(ctx.chat.id, ctx.from.id, task);
+    return ctx.reply(
+      `📝 Editing: ${task.title}\n` +
+      `[${task.criticality}] ${task.area} · ${task.effortMins}m · ${task.assignedTo}\n\n` +
+      `Reply with what to change, e.g. "make it HIGH" or "change area to Bathroom, 45 mins"`
+    );
+  }));
+
   bot.command("settings", requireMember(async (ctx) => {
     const settings = await getSettings(ctx.household.id);
     await ctx.reply(
@@ -168,6 +183,7 @@ async function registerCommands(bot) {
       "/pending — all pending tasks (numbered)",
       "/done <number or name> — mark a task complete",
       "/delete <number or name> — delete a task",
+      "/edit <number or name> — edit a task's details",
       "/settings — show settings",
       "/leavehousehold — leave this household",
       "/help — this message"

--- a/src/handlers/correction-session.js
+++ b/src/handlers/correction-session.js
@@ -31,6 +31,10 @@ function getSession(chatId, userId) {
   return session;
 }
 
+function startSessionForTask(chatId, userId, task) {
+  sessions.set(keyOf(chatId, userId), { task, expiresAt: Date.now() + TTL_MS });
+}
+
 function clearSession(chatId, userId) {
   sessions.delete(keyOf(chatId, userId));
 }
@@ -44,6 +48,7 @@ function purgeExpiredSessions() {
 module.exports = {
   setRecentTask,
   startSession,
+  startSessionForTask,
   getSession,
   clearSession,
   purgeExpiredSessions

--- a/test/handlers/commands.test.js
+++ b/test/handlers/commands.test.js
@@ -14,6 +14,7 @@ const getSettings = mock.fn(async () => ({ calendarTime: '18:00', calendarDurati
 const updateSettings = mock.fn(async () => {});
 
 const refreshScheduleForHousehold = mock.fn(async () => {});
+const startSessionForTask = mock.fn();
 
 require.cache[require.resolve('../../src/services/supabase')] = {
   exports: { getAreas, addArea, removeArea, bulkComplete, deleteTask, getHouseholdMembers, getMembership, getIncompleteTasksByPriority, getSettings, updateSettings }
@@ -23,6 +24,9 @@ require.cache[require.resolve('../../src/cron/scheduler')] = {
 };
 require.cache[require.resolve('../../src/services/witty-response')] = {
   exports: { generateWittyReply: mock.fn(async () => null) }
+};
+require.cache[require.resolve('../../src/handlers/correction-session')] = {
+  exports: { startSessionForTask }
 };
 // guards and validators have no external deps — let them run natively
 delete require.cache[require.resolve('../../src/middleware/guards')];
@@ -44,6 +48,8 @@ function makeCtx(text, overrides = {}) {
     householdUser: { id: 'u1', telegramId: '111' },
     memberRole: 'admin',
     message: { text },
+    chat: { id: 'chat1' },
+    from: { id: 'user1' },
     reply: mock.fn(async () => {}),
     ...overrides
   };
@@ -65,6 +71,7 @@ describe('commands', () => {
     getSettings.mock.resetCalls();
     updateSettings.mock.resetCalls();
     refreshScheduleForHousehold.mock.resetCalls();
+    startSessionForTask.mock.resetCalls();
 
     getAreas.mock.mockImplementation(async () => []);
     getHouseholdMembers.mock.mockImplementation(async () => []);
@@ -296,6 +303,46 @@ describe('commands', () => {
       await handlers['settimezone'](ctx);
       assert.equal(updateSettings.mock.calls.length, 0);
       assert.ok(ctx.reply.mock.calls[0].arguments[0].includes('Invalid timezone'));
+    });
+  });
+
+  describe('/edit', () => {
+    it('replies with usage error when no argument given', async () => {
+      const ctx = makeCtx('/edit');
+      await handlers['edit'](ctx);
+      assert.ok(ctx.reply.mock.calls[0].arguments[0].includes('Usage'));
+      assert.equal(startSessionForTask.mock.calls.length, 0);
+    });
+
+    it('starts session and shows edit prompt for task by number', async () => {
+      const task = { id: 't1', title: 'Fix tap', criticality: 'HIGH', effortMins: 30, area: 'Kitchen', assignedTo: 'Me' };
+      getIncompleteTasksByPriority.mock.mockImplementation(async () => [task]);
+      const ctx = makeCtx('/edit 1');
+      await handlers['edit'](ctx);
+      assert.equal(startSessionForTask.mock.calls.length, 1);
+      assert.equal(startSessionForTask.mock.calls[0].arguments[2], task);
+      const reply = ctx.reply.mock.calls[0].arguments[0];
+      assert.ok(reply.includes('Fix tap'));
+      assert.ok(reply.includes('📝'));
+    });
+
+    it('starts session and shows edit prompt for task by name substring', async () => {
+      const task = { id: 't1', title: 'Fix tap', criticality: 'HIGH', effortMins: 30, area: 'Kitchen', assignedTo: 'Me' };
+      getIncompleteTasksByPriority.mock.mockImplementation(async () => [task]);
+      const ctx = makeCtx('/edit fix tap');
+      await handlers['edit'](ctx);
+      assert.equal(startSessionForTask.mock.calls.length, 1);
+      assert.equal(startSessionForTask.mock.calls[0].arguments[2], task);
+    });
+
+    it('replies "not found" when query matches nothing', async () => {
+      getIncompleteTasksByPriority.mock.mockImplementation(async () => [
+        { id: 't1', title: 'Fix tap', criticality: 'HIGH', effortMins: 30, area: 'Kitchen', assignedTo: 'Me' }
+      ]);
+      const ctx = makeCtx('/edit paint fence');
+      await handlers['edit'](ctx);
+      assert.equal(startSessionForTask.mock.calls.length, 0);
+      assert.ok(ctx.reply.mock.calls[0].arguments[0].includes('not found'));
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `/edit <number or name>` as a member-level command — selects any task from the pending list and starts a correction session on it
- Adds `startSessionForTask(chatId, userId, task)` to `correction-session.js` — starts a session directly from a task object, bypassing the "most-recent-task-only" restriction of the existing `startSession()`
- The user's next free-text reply is automatically routed through the existing `correctTask → updateTask → formatTaskChanges` pipeline with no new logic needed there
- JARVIS `task_corrected` quip fires automatically (already wired in `correction.js`)
- `/help` updated to include the new command

## Before / After

**Before:** Corrections only worked within 10 minutes of adding a task, via "correct" or "fix this". No way to edit task #3 from a 20-task pending list.

**After:**
```
/edit 3          → edit prompt showing task #3 details
/edit kitchen    → matches by name substring
make it HIGH, 45 mins  → diff card + JARVIS quip
```

## Test plan

- [x] 222/222 tests pass (4 new tests covering usage error, by-number, by-name, not-found)
- [ ] Smoke test in Telegram: `/pending` → `/edit 2` → reply with correction → verify diff shown and DB updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)