### PR TITLE
docs: fix stale references in planning docs

### DIFF
--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -52,14 +52,15 @@ node-cron (per household)
 | `src/middleware/guards.js` | `requireMember(handler)` — blocks if no household; `requireAdmin(handler)` — blocks if role is not admin |
 | `src/handlers/onboarding.js` | `/start`, `/create`, `/join` — bypass household guard; handle first contact |
 | `src/handlers/admin.js` | `/invite`, `/members`, `/removemember`, `/promote`, `/demote`, `/leavehousehold` |
-| `src/handlers/commands.js` | `/areas`, `/addarea`, `/removearea`, `/queue`, `/pending`, `/done`, `/delete`, `/settings`, `/settime`, `/setduration`, `/settimezone`, `/help` |
+| `src/handlers/commands.js` | `/areas`, `/addarea`, `/removearea`, `/queue`, `/pending`, `/done`, `/delete`, `/edit`, `/settings`, `/settime`, `/setduration`, `/settimezone`, `/help` |
 | `src/handlers/message.js` | Routes free text: correction → completion reply → task capture |
 | `src/handlers/correction.js` | Calls Gemini `correctTask()`, applies patch via `updateTask()`, clears session |
-| `src/handlers/correction-session.js` | In-memory Map keyed by `chatId:userId`; 10-minute TTL per correction session |
+| `src/handlers/correction-session.js` | In-memory Map keyed by `chatId:userId`; 10-minute TTL per correction session; `startSessionForTask()` allows starting a session on any task (used by `/edit`) |
 | `src/handlers/complete.js` | Parses completion replies (yes / skip / no / free text); calls `bulkComplete()` |
 | `src/handlers/queue-session.js` | In-memory Maps for queued task lists and 2-hour completion windows; keyed by telegramId |
 | `src/cron/scheduler.js` | `Map<householdId, {queueJob, completionJob}>` — one cron pair per household; `refreshScheduleForHousehold()` called on settings change |
 | `src/services/gemini.js` | `classifyTask(text, areas)` and `correctTask(task, text)` — Gemini API calls with JSON parsing and field normalisation |
+| `src/services/witty-response.js` | `generateWittyReply(action, context)` — Gemini-powered JARVIS-style confirmation lines; returns `null` on any failure so callers always fall back to static text |
 | `src/services/supabase.js` | All DB operations; every function scoped to `householdId`; `bulkComplete` handles recurring vs non-recurring tasks differently |
 | `src/services/queue-builder.js` | Greedy bin-pack: CRITICAL+HIGH always included, then `quick-win`-tagged MEDIUM/LOW up to the duration budget |
 | `src/services/calendar.js` | Builds a Google Calendar TEMPLATE URL for the day's queue |

--- a/docs/engineering/commands-reference.md
+++ b/docs/engineering/commands-reference.md
@@ -80,6 +80,20 @@ Permanently deletes a pending task. Useful for wrongly captured tasks.
 /delete fridge
 ```
 
+### `/edit <number or name>`
+
+Edits any pending task's details — title, area, criticality, effort, assignee, or tags. Supports 1-based index from `/pending` or case-insensitive partial name match. After the edit prompt, reply in plain English with what to change; the AI applies only the fields you mention.
+
+```
+/edit 3
+→ 📝 Editing: Deep clean fridge
+  [MEDIUM] Kitchen · 45m · Me
+
+  Reply with what to change, e.g. "make it HIGH" or "change area to Bathroom, 45 mins"
+
+make it HIGH, 30 mins
+```
+
 ### `/queue`
 
 Manually triggers today's queue — same output as the scheduled cron job. Does not affect the cron schedule.
@@ -219,7 +233,7 @@ Any message that is not a command and does not trigger another flow is treated a
 The kitchen tap is dripping
 ```
 
-### Correction
+### Correction (most recent task)
 
 Within 10 minutes of capturing a task, type `correct` or `fix this` to start a correction, then describe the change:
 
@@ -228,11 +242,15 @@ correct
 → make it HIGH and assign to Professional
 ```
 
-Or for the most recently added task, just describe the correction directly:
+Or describe the correction directly:
 
 ```
 actually it should be CRITICAL
 ```
+
+### Editing any pending task
+
+Use `/edit <number or name>` to correct any task in the pending list, not just the most recently added one. See the `/edit` command above.
 
 ### Completion replies
 

--- a/docs/engineering/development.md
+++ b/docs/engineering/development.md
@@ -51,7 +51,7 @@ The bot uses long-polling (not webhooks) so it works without a public URL.
 ## Running tests
 
 ```bash
-npm test                                    # all 218 tests
+npm test                                    # all 222 tests
 node --test test/unit/validators.test.js    # single file
 node --test test/handlers/                  # one directory
 ```
@@ -78,7 +78,7 @@ test/
     message.test.js           # message routing
     onboarding.test.js        # /create, /join
     admin.test.js             # admin commands
-    commands.test.js          # member commands including /done, /delete
+    commands.test.js          # member commands including /done, /delete, /edit
   middleware/
     household.test.js         # household resolution middleware
     guards.test.js            # requireMember, requireAdmin

--- a/docs/home_os_PRD.md
+++ b/docs/home_os_PRD.md
@@ -1,7 +1,9 @@
 # Home OS — Product Requirements Document
 **Version:** 1.0  
-**Status:** Ready for build  
+**Status:** Pre-implementation planning document — superseded by live implementation  
 **Last updated:** April 2026
+
+> **Note:** This document was written before the multi-tenant rewrite. Several sections (auth model, DB schema, command list, env vars) reflect the original single-tenant design and are no longer accurate. For the current architecture see `docs/engineering/architecture.md`; for the current command reference see `docs/engineering/commands-reference.md`; for environment setup see `docs/engineering/development.md`.
 
 ---
 
@@ -29,7 +31,7 @@ Home OS is an AI-powered home task management system for a family with kids. It 
 | Spouse | Telegram, authorised by user ID | Add tasks, voice notes (v2) |
 | Bot | Automated | Classify, queue, remind, complete |
 
-**Authorisation:** Hardcoded list of Telegram numeric user IDs in env var. All other users are silently ignored.
+**Authorisation:** Multi-tenant, invite-based. Any Telegram user can start the bot; they join a household via `/create` (becomes admin) or `/join <invite-code>` (becomes member). Access is controlled by `requireMember` / `requireAdmin` middleware guards backed by the `household_members` table.
 
 ---
 
@@ -118,8 +120,8 @@ name       text  UNIQUE NOT NULL
 created_at timestamptz auto
 ```
 
-**Default seed:**
-Kitchen, Bathroom, Master Bedroom, Kids Room, Living Room, Study, Garden, Garage, General
+**Default seed (12 areas):**
+Kitchen, Bathroom, Common Bathroom, Living Room, Master Bedroom, Guest Bedroom, Office, Garden, Balcony, Utility Room, Entrance, General
 
 ### 4.3 `settings` Table
 ```sql
@@ -321,12 +323,15 @@ Did you complete today's tasks? Reply:
 ## 8. Environment Variables
 
 ```
-TELEGRAM_BOT_TOKEN=
-TELEGRAM_AUTHORISED_IDS=123456789,987654321   # comma-separated numeric IDs
-GEMINI_API_KEY=
-SUPABASE_URL=https://xyzxyz.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=                    # use service_role, not anon key
+TELEGRAM_BOT_TOKEN=           # from @BotFather
+GEMINI_API_KEY=               # from aistudio.google.com
+GEMINI_MODEL=                 # optional; defaults to gemini-2.5-flash
+SUPABASE_URL=                 # https://<project>.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=    # Settings → API → service_role (NOT anon key)
+COMPLETION_PROMPT_DELAY_MINS= # optional; defaults to 60
 ```
+
+> Note: `TELEGRAM_AUTHORISED_IDS` from the original single-tenant design has been removed. Access is now managed through household membership.
 
 > ⚠️ Use `SUPABASE_SERVICE_ROLE_KEY` (not anon key) — the bot is server-side only and needs to bypass RLS.
 
@@ -419,7 +424,7 @@ After deployment, verify these flows end to end:
 
 | Service | Free Tier | Expected Usage | Cost |
 |---|---|---|---|
-| Gemini 2.5 Flash | 1,500 req/day | ~10–20 req/day | $0 |
+| Gemini 2.5 Flash | 1,500 req/day free (per-minute rate limit applies) | ~20–40 req/day | $0 |
 | Supabase | 500MB, unlimited API calls | <1MB for years | $0 |
 | Railway.app | $5 credit/month | ~$1–2/month | $0–3/month |
 | Voice (v2) | Gemini native audio | Negligible | $0 |

--- a/docs/home_os_PRD.md
+++ b/docs/home_os_PRD.md
@@ -8,7 +8,7 @@
 ## 1. Product Overview
 
 ### 1.1 What It Is
-Home OS is an AI-powered home task management system for a family with kids. It accepts natural language task input via a Telegram bot, classifies tasks using Gemini 2.0 Flash, persists them in Supabase, and proactively manages daily execution via Google Calendar integration and cron-based automation.
+Home OS is an AI-powered home task management system for a family with kids. It accepts natural language task input via a Telegram bot, classifies tasks using Gemini 2.5 Flash, persists them in Supabase, and proactively manages daily execution via Google Calendar integration and cron-based automation.
 
 ### 1.2 Problem It Solves
 - Home tasks are captured informally (mental notes, WhatsApp messages) and lost
@@ -43,7 +43,7 @@ You / Spouse (Telegram text message)
         ↓
   Authorised user check
         ↓
-  Gemini 2.0 Flash  ←  system prompt with home areas
+  Gemini 2.5 Flash  ←  system prompt with home areas
         ↓
   Supabase (Postgres) — write classified task
         ↓
@@ -57,11 +57,11 @@ You / Spouse (Telegram text message)
 | Layer | Choice | Reason |
 |---|---|---|
 | Bot runtime | Node.js 20 + Telegraf.js | Lightweight, excellent Telegram support |
-| AI | Gemini 2.0 Flash | Free tier (1500 req/day), reliable JSON output |
+| AI | Gemini 2.5 Flash | Free tier (1500 req/day), reliable JSON output |
 | Database | Supabase (Postgres) | Free tier, queryable, visual dashboard, open source |
 | Scheduler | node-cron | Daily queue post + completion prompt |
 | Hosting | Railway.app | Free tier, always-on, GitHub auto-deploy |
-| Voice (v2) | Gemini 2.0 native audio | No Whisper needed |
+| Voice (v2) | Gemini 2.5 native audio | No Whisper needed |
 
 ### 3.3 Project Structure
 ```
@@ -74,7 +74,7 @@ home-os-bot/
 │   │   ├── complete.js        ← bulk complete confirmation flow
 │   │   └── commands.js        ← /areas /queue /settings etc.
 │   ├── services/
-│   │   ├── gemini.js          ← Gemini 2.0 Flash API wrapper
+│   │   ├── gemini.js          ← Gemini 2.5 Flash API wrapper
 │   │   ├── supabase.js        ← all DB read/write operations
 │   │   └── calendar.js        ← Google Calendar URL builder
 │   ├── cron/
@@ -374,7 +374,7 @@ SUPABASE_SERVICE_ROLE_KEY=                    # use service_role, not anon key
 
 ## 12. V2 Backlog (After Stable)
 
-- [ ] Voice note support — Gemini 2.0 native audio transcription
+- [ ] Voice note support — Gemini 2.5 native audio transcription
 - [ ] Recurrence engine — auto-recreate tasks on schedule (schema already ready)
 - [ ] Weekly summary — every Sunday: *"7 tasks completed, 3 pending"*
 - [ ] Completion streak — gamification for consistency
@@ -419,7 +419,7 @@ After deployment, verify these flows end to end:
 
 | Service | Free Tier | Expected Usage | Cost |
 |---|---|---|---|
-| Gemini 2.0 Flash | 1,500 req/day | ~10–20 req/day | $0 |
+| Gemini 2.5 Flash | 1,500 req/day | ~10–20 req/day | $0 |
 | Supabase | 500MB, unlimited API calls | <1MB for years | $0 |
 | Railway.app | $5 credit/month | ~$1–2/month | $0–3/month |
 | Voice (v2) | Gemini native audio | Negligible | $0 |

--- a/docs/home_os_architecture.md
+++ b/docs/home_os_architecture.md
@@ -1,8 +1,10 @@
 # Home OS — Architecture Document
 **Version:** 1.0  
-**Status:** Final — Ready for Implementation  
+**Status:** Pre-implementation planning document — superseded by live implementation  
 **Last Updated:** April 2026  
 **Prepared by:** Architecture Review
+
+> **Note:** This document was written before the multi-tenant rewrite. Sections on auth (§4.1), config (§4.5), environment variables (§7.2), and the security table (§8) reflect the original single-tenant design. For the current architecture see `docs/engineering/architecture.md`.
 
 ---
 
@@ -79,10 +81,11 @@ Home OS is a **serverless-first, AI-powered home task management system** delive
 
 **Auth Guard (middleware):**
 ```
-Request → Parse Telegram user_id → Check AUTHORISED_IDS array
-  ├── Match found → next()
-  └── No match   → ctx.stop() — silent drop, no reply
+Request → household middleware → upsert user → resolve household membership
+  ├── Member found → ctx.household set → next()
+  └── No household → route to onboarding (/create or /join)
 ```
+> Note: the original single-tenant design used a flat `AUTHORISED_IDS` env-var whitelist. The live system uses `household_members` DB table with `requireMember`/`requireAdmin` guards.
 
 ---
 
@@ -206,12 +209,12 @@ Output: queue[], remaining (buffer minutes)
 
 ### 4.5 Config — `src/config.js`
 
-- Loads and exports all env vars
-- `AUTHORISED_IDS` parsed from comma-separated string to `number[]`
+- Loads and validates all env vars
 - Criticality order map: `{ CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3 }`
 - Tag taxonomy array
 - Assigned-to options array
 - `effortMins` clamp bounds: `[1, 480]`
+- No `AUTHORISED_IDS` — access is managed through household membership in the DB
 
 ---
 
@@ -340,11 +343,14 @@ supabase.updateTask(id, patch)
 
 ```
 TELEGRAM_BOT_TOKEN            # from @BotFather
-TELEGRAM_AUTHORISED_IDS       # comma-separated: 123456789,987654321
 GEMINI_API_KEY                # from aistudio.google.com
+GEMINI_MODEL                  # optional; defaults to gemini-2.5-flash
 SUPABASE_URL                  # https://xyzxyz.supabase.co
 SUPABASE_SERVICE_ROLE_KEY     # service_role key — NOT anon key
+COMPLETION_PROMPT_DELAY_MINS  # optional; defaults to 60
 ```
+
+> Note: `TELEGRAM_AUTHORISED_IDS` from the original single-tenant design has been removed. Access is managed through household membership.
 
 > **Security note:** `service_role` key bypasses Supabase RLS. Never expose to any client-side code. This is a server-only bot — safe by architecture.
 
@@ -361,7 +367,7 @@ Local dev → git push main → Railway GitHub webhook → auto-build → deploy
 
 | Concern | Mitigation |
 |---|---|
-| Unauthorised Telegram users | Auth guard middleware — silent drop on every message/command |
+| Unauthorised Telegram users | Household middleware — upserts user, routes to onboarding if no household; `requireMember`/`requireAdmin` guards reject commands |
 | Supabase key exposure | Service role key in env var only, never in code or logs |
 | Gemini prompt injection | System prompt clearly bounds role; user input is `content`, not `system` |
 | Correction state hijack | State keyed by `chatId:userId` — user can only correct their own initiated tasks |

--- a/docs/home_os_architecture.md
+++ b/docs/home_os_architecture.md
@@ -8,7 +8,7 @@
 
 ## 1. Executive Summary
 
-Home OS is a **serverless-first, AI-powered home task management system** delivered via a Telegram bot. The system accepts natural language input, classifies tasks using Gemini 2.0 Flash, persists to a managed Postgres instance (Supabase), and automates daily execution via cron-based scheduling and Google Calendar integration.
+Home OS is a **serverless-first, AI-powered home task management system** delivered via a Telegram bot. The system accepts natural language input, classifies tasks using Gemini 2.5 Flash, persists to a managed Postgres instance (Supabase), and automates daily execution via cron-based scheduling and Google Calendar integration.
 
 **Design Philosophy:** Thin bot layer. Dumb transport. Smart AI. Reliable persistence.
 
@@ -38,7 +38,7 @@ Home OS is a **serverless-first, AI-powered home task management system** delive
                │                      │
                ▼                      ▼
 ┌──────────────────────┐   ┌─────────────────────────────────────┐
-│  Gemini 2.0 Flash    │   │  Supabase (Managed Postgres)        │
+│  Gemini 2.5 Flash    │   │  Supabase (Managed Postgres)        │
 │  Google AI Studio    │   │  tables: tasks, areas, settings     │
 │  REST API            │   │  REST + Realtime API                │
 └──────────────────────┘   └─────────────────────────────────────┘
@@ -283,7 +283,7 @@ User text
 buildSystemPrompt(areas[])   ← dynamically injects current area list
     │
     ▼
-Gemini 2.0 Flash API call
+Gemini 2.5 Flash API call
     │
     ▼
 Strip markdown fences → JSON.parse()
@@ -447,7 +447,7 @@ Schema is already ready. When building v2, these layers need changes:
 | Decision | Alternatives Considered | Rationale |
 |---|---|---|
 | Telegraf.js | node-telegram-bot-api, Grammy | Best DX, TypeScript support, active community |
-| Gemini 2.0 Flash | GPT-4o-mini, Claude Haiku | Free tier 1500 req/day; sufficient for home use |
+| Gemini 2.5 Flash | GPT-4o-mini, Claude Haiku | Free tier 1500 req/day; sufficient for home use |
 | Supabase | PlanetScale, Firebase, SQLite | Free managed Postgres + visual dashboard for ops |
 | Railway | Render, Fly.io, VPS | Simplest GitHub deploy; free tier fits single process |
 | GCal TEMPLATE URL | OAuth + Calendar API | No credentials, no token refresh, always works |

--- a/docs/home_os_execution_plan.md
+++ b/docs/home_os_execution_plan.md
@@ -2,32 +2,34 @@
 **Version:** 1.0
 **Last updated:** April 2026
 
+> **Note:** This document was written before the multi-tenant rewrite. Phase 0 credentials, Phase 1 schema scripts, Phase 5 env vars, and Phase 6 smoke tests reflect the original single-tenant design. For the current setup guide see `docs/engineering/development.md`.
+
 ---
 
 ## Phase 0 — Credentials (~15 mins, you do this)
 
 ```
 ✅ Telegram bot token          — from @BotFather
-⬜ Your Telegram user ID       — message @userinfobot
-⬜ Spouse Telegram user ID     — ask spouse to message @userinfobot
 ⬜ Gemini API key              — aistudio.google.com → Get API Key
 ⬜ Supabase Project URL        — supabase.com → Settings → API
 ⬜ Supabase service_role key   — supabase.com → Settings → API (NOT anon key)
 ⬜ Railway account             — railway.app, sign up with GitHub
 ```
 
+> Note: Individual Telegram user IDs are no longer needed at setup time. Access is managed via household membership — users join by running `/create` or `/join <invite-code>` in the bot.
+
 ---
 
 ## Phase 1 — Supabase Schema (~10 mins)
 
 - [ ] Go to Supabase → SQL Editor → New Query
-- [ ] Run `home_os_schema.sql` (creates areas, settings, tasks tables + indexes + trigger)
-- [ ] Verify: 9 rows in areas, 1 row in settings, 0 rows in tasks
+- [ ] Run scripts in order: `scripts/create_schema.sql` → `scripts/multi_tenant_schema.sql`
+- [ ] Verify: 12 rows in areas (per household after first `/create`), tables: households, users, household_members, invite_codes, tasks, areas, settings
 - [ ] Note: tasks table includes recurrence columns (v2-ready, schema reserved now)
 
 **Files:**
-- `home_os_schema.sql` — full schema script
-- `home_os_tasks_table.sql` — tasks table only (updated with recurrence columns)
+- `scripts/create_schema.sql` — base schema (fresh deploy)
+- `scripts/multi_tenant_schema.sql` — adds multi-tenant tables, alters areas/tasks/settings
 
 ---
 
@@ -62,10 +64,10 @@ home-os-bot/
 ## Phase 3 — Core Pipeline (biggest chunk)
 
 ### 3a. `config.js`
-- Load all env vars
-- Export AUTHORISED_IDS as parsed array
+- Load and validate all env vars
 - Export criticality order map
 - Export default tag list
+- No `AUTHORISED_IDS` — access is managed through household membership
 
 ### 3b. `services/gemini.js`
 - `classifyTask(text, areas)` → structured JSON task object
@@ -149,10 +151,11 @@ home-os-bot/
 - [ ] Add all env vars in Railway dashboard:
   ```
   TELEGRAM_BOT_TOKEN
-  TELEGRAM_AUTHORISED_IDS
   GEMINI_API_KEY
+  GEMINI_MODEL            (optional — defaults to gemini-2.5-flash)
   SUPABASE_URL
   SUPABASE_SERVICE_ROLE_KEY
+  COMPLETION_PROMPT_DELAY_MINS  (optional — defaults to 60)
   ```
 - [ ] Railway auto-detects Node.js, runs `node src/bot.js`
 - [ ] Verify bot is online — send `/help` on Telegram
@@ -163,7 +166,7 @@ home-os-bot/
 
 - [ ] Send *"Kitchen tap leaking badly"* → get CRITICAL card back
 - [ ] Reply *"make it HIGH"* → get corrected card, only criticality changed
-- [ ] `/areas` → see 9 default areas
+- [ ] `/areas` → see 12 default areas
 - [ ] `/addarea Terrace` → confirmation, check Supabase dashboard
 - [ ] `/queue` → today's priority list + Google Calendar link
 - [ ] Open Calendar link → event has correct tasks in description
@@ -178,11 +181,14 @@ home-os-bot/
 
 ```
 TELEGRAM_BOT_TOKEN=           # from @BotFather
-TELEGRAM_AUTHORISED_IDS=      # comma-separated: 123456789,987654321
 GEMINI_API_KEY=               # from aistudio.google.com
+GEMINI_MODEL=                 # optional; defaults to gemini-2.5-flash
 SUPABASE_URL=                 # https://xyzxyz.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=    # from Supabase → Settings → API (service_role)
+COMPLETION_PROMPT_DELAY_MINS= # optional; defaults to 60
 ```
+
+> Note: `TELEGRAM_AUTHORISED_IDS` from the original single-tenant design has been removed. Access is managed through household membership.
 
 ---
 
@@ -194,7 +200,7 @@ SUPABASE_SERVICE_ROLE_KEY=    # from Supabase → Settings → API (service_role
 - [x] Daily queue cron + Google Calendar link auto-post
 - [x] Completion confirmation flow
 - [x] All bot commands
-- [x] Authorised users whitelist
+- [x] Multi-tenant household system (invite-based, `/create` + `/join`)
 - [x] Railway deployment
 
 ## V2 Backlog

--- a/docs/home_os_execution_plan.md
+++ b/docs/home_os_execution_plan.md
@@ -199,7 +199,7 @@ SUPABASE_SERVICE_ROLE_KEY=    # from Supabase → Settings → API (service_role
 
 ## V2 Backlog
 
-- [ ] Voice note support — Gemini 2.0 native audio
+- [ ] Voice note support — Gemini 2.5 native audio
 - [ ] Recurrence engine — schema already ready, 7 layers to implement
   - Gap: scheduler (`src/cron/scheduler.js`) never queries `next_due_date`; recurring tasks are classified and stored but never auto-regenerated when due
   - Need: a daily cron job that finds tasks WHERE `is_recurring=true AND next_due_date <= today`, resets `completed=false`, and advances `next_due_date` by `recurrence_interval_days`

--- a/docs/users/member-guide.md
+++ b/docs/users/member-guide.md
@@ -45,6 +45,35 @@ Alternatively, type `correct` or `fix this` to start a correction on your most r
 
 ---
 
+## Editing any pending task
+
+Use `/edit` to change the details of any task in the pending list — not just the one you just added.
+
+### By number (from /pending list)
+
+```
+/edit 3
+```
+
+### By name (partial match works)
+
+```
+/edit exhaust fan
+```
+
+The bot shows the current task details and prompts you to describe the change:
+
+```
+📝 Editing: Fix bathroom exhaust fan
+[HIGH] Bathroom · 30m · Me
+
+Reply with what to change, e.g. "make it CRITICAL" or "change area to Kitchen, 45 mins"
+```
+
+Reply in plain English — the AI applies only the fields you mention, leaving everything else unchanged.
+
+---
+
 ## Viewing pending tasks
 
 ```

--- a/docs/users/quick-start.md
+++ b/docs/users/quick-start.md
@@ -127,6 +127,7 @@ The bot corrects only the fields you mentioned and confirms the change.
 | `/pending` | See all tasks, numbered |
 | `/done 2` | Mark task #2 complete |
 | `/done fix tap` | Mark by name (partial match works) |
+| `/edit 2` | Edit task #2 details (area, priority, effort…) |
 | `/delete 3` | Delete a wrongly captured task |
 | `/queue` | Manually trigger today's queue |
 | `/help` | Full command list |


### PR DESCRIPTION
## Summary

- Add deprecation notices to all three planning docs pointing to current engineering docs
- Remove `TELEGRAM_AUTHORISED_IDS` — doesn't exist in the multi-tenant codebase; anyone following these docs would add a non-existent env var
- Fix Gemini version references: 2.0 → 2.5 Flash (9 occurrences across 3 files)
- Fix area count: 9 → 12 (current default seed)
- Fix schema script names to match actual scripts in `scripts/`
- Fix auth model description (flat whitelist → household membership)
- Add `GEMINI_MODEL` and `COMPLETION_PROMPT_DELAY_MINS` to env var reference
- Update V1 scope: "Authorised users whitelist" → "Multi-tenant household system"

## Test plan

- [ ] No code changes — docs only
- [ ] Verify planning docs no longer reference `TELEGRAM_AUTHORISED_IDS`
- [ ] Verify deprecation notices point to correct current docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)