### PR TITLE
docs: add Architecture Decision Records (ADR-001–008)

### DIFF
--- a/docs/adr/ADR-001-telegram-as-primary-interface.md
+++ b/docs/adr/ADR-001-telegram-as-primary-interface.md
@@ -1,0 +1,39 @@
+# ADR-001: Telegram as the sole user interface
+
+**Date:** April 2026  
+**Status:** Accepted
+
+## Context
+
+Home OS needs to be used by two adults (and eventually other family members) with zero onboarding friction. The core UX hypothesis is: if adding a task requires opening an app, finding a form, and tapping through fields, it won't happen consistently. Tasks will continue to be captured in WhatsApp threads and mental notes.
+
+The system needs to feel like messaging — not like software.
+
+## Decision
+
+Telegram is the only interface. There is no web dashboard, no mobile app, and no API for third-party clients. All interactions happen through the Telegram Bot API.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+|---|---|
+| Native iOS/Android app | Requires App Store install and login — high friction for a household with varied tech comfort. Two to four weeks of additional build time before first usable version. |
+| WhatsApp Business API | No free-tier bot API. Message template approval adds friction. Terms of service restrict automation use cases. |
+| Web app | Requires a URL to remember, a login flow, and deliberate navigation. Doesn't integrate into existing daily messaging behaviour. |
+| Voice assistant (Google/Alexa) | Poor for structured task capture — ambiguity in hands-free transcription. No visual confirmation card. Kids triggering accidental captures. |
+| iMessage | Apple-only. Spouse may be on Android. |
+
+## Consequences
+
+**Positive:**
+- Zero install. Everyone with Telegram can use it immediately.
+- Works on any device, any OS, offline-tolerant (Telegram queues messages).
+- Bot API is stable, well-documented, and free for our scale.
+- Natural language input via free text matches how people already communicate about home tasks.
+- Confirmation cards appear inline in the chat — easy to spot and correct immediately.
+
+**Negative / trade-offs:**
+- Telegram-locked. If Telegram changes its Bot API, pricing, or availability in a region, the entire UX layer is at risk.
+- No rich UI: no drag-to-reorder, no checklist UI, no calendar view native to the app.
+- Multi-media input (photos of broken things) requires extra handling that is out of scope in v1.
+- Users who don't have Telegram cannot use the system.

--- a/docs/adr/ADR-002-gemini-for-ai-classification.md
+++ b/docs/adr/ADR-002-gemini-for-ai-classification.md
@@ -1,0 +1,43 @@
+# ADR-002: Gemini 2.5 Flash for AI task classification
+
+**Date:** April 2026  
+**Status:** Accepted
+
+## Context
+
+The value proposition of Home OS is that users send natural language messages and the system figures out criticality, area, effort, assignee, tags, and recurrence. This requires a language model capable of reliably returning structured JSON from varied, often terse, real-world input ("bathroom tap dripping again", "kids school bag needs replacing before Monday").
+
+The model needs to:
+- Return valid JSON every time, with no markdown prose wrapping it
+- Handle ambiguous or partial descriptions gracefully
+- Run within a budget of $0/month for a home use case (~20–40 calls/day)
+
+## Decision
+
+Google Gemini 2.5 Flash via the `@google/genai` SDK. The model is configured via the `GEMINI_MODEL` env var (defaulting to `gemini-2.5-flash`) so it can be swapped without code changes.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+|---|---|
+| GPT-4o-mini (OpenAI) | No free tier at our call volume. ~$0.15/1M input tokens — negligible cost, but adds a billing relationship for a zero-cost home tool. |
+| Claude Haiku (Anthropic) | Similar cost concern. Excellent JSON output, but Gemini free tier makes it hard to justify. |
+| Local LLM (Ollama + Mistral) | No always-on free hosting for a local model. Would require a self-hosted machine running 24/7. Latency unpredictable on consumer hardware. |
+| Rule-based parser | Regex + keyword matching cannot handle the variety of natural language task descriptions. Would require constant maintenance and would miss edge cases constantly. |
+| Gemini 2.5 Pro | Higher quality but not needed for structured extraction from short texts; slower and more expensive. Flash is sufficient. |
+
+## Consequences
+
+**Positive:**
+- 1,500 requests/day free on Google AI Studio — comfortably above our ~40 req/day peak.
+- Fast response time (Flash is optimised for low latency).
+- Reliable JSON output when instructed with "Return ONLY valid JSON".
+- Native support for dynamic system prompts (areas list injected per request).
+- Model version can be upgraded by changing one env var.
+
+**Negative / trade-offs:**
+- Free tier rate limit: 5 requests/minute. Under normal single-household use this is never hit; if load increases (many households, burst usage), requests will be throttled.
+- Google dependency: if the free tier terms change, there is a real cost to absorb or a migration to do.
+- Both the primary classification prompt and the correction prompt consume a Gemini call. A third call is made for witty confirmations (`witty-response.js`). Total: up to 3 Gemini calls per task-add interaction.
+- JSON output still requires defensive parsing: markdown fence stripping, field clamping, enum defaulting. Model can occasionally return malformed output under unexpected input.
+- No offline or fallback classification if the Gemini API is unavailable. Task capture fails gracefully with a user-visible error message.

--- a/docs/adr/ADR-003-supabase-for-persistence.md
+++ b/docs/adr/ADR-003-supabase-for-persistence.md
@@ -1,0 +1,40 @@
+# ADR-003: Supabase (managed Postgres) for persistence
+
+**Date:** April 2026  
+**Status:** Accepted
+
+## Context
+
+Home OS needs persistent storage for tasks, areas, settings, users, households, and invite codes. The storage layer must:
+- Support relational queries (tasks filtered by household, ordered by criticality, scoped by completion status)
+- Be queryable outside the bot for debugging and ops (e.g. "what tasks are pending for this household right now?")
+- Run free at our scale (<1 MB of data for years of typical usage)
+- Be forward-compatible with a potential future mobile app that would need row-level security and JWT-scoped access
+
+## Decision
+
+Supabase, accessed via the `@supabase/supabase-js` client using the `service_role` key. All SQL operations are plain Supabase queries — no Supabase-specific features (Realtime, Edge Functions, Auth) are used in v1.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+|---|---|
+| Firebase Firestore | NoSQL document model makes priority-ordered queries on tasks awkward. No free SQL joins. Dashboard is less useful for tabular task ops inspection. |
+| PlanetScale | MySQL-compatible but no free tier as of 2024. Branching model adds unnecessary complexity for a single developer. |
+| SQLite (local file) | No remote access — can't inspect data from the dashboard without SSH into Railway. No concurrent access from future clients. Data lives only on the Railway instance. |
+| MongoDB Atlas | NoSQL — same join/query concerns as Firebase. Aggregation pipeline is heavier than plain SQL for sorted task lists. |
+| Raw Postgres (managed, e.g. Neon) | Viable, but Supabase wraps Postgres with a REST API, dashboard, and RLS support — all of which are useful. No downside over raw Postgres at this scale. |
+
+## Consequences
+
+**Positive:**
+- Free tier: 500MB, unlimited API calls — more than sufficient indefinitely.
+- Supabase dashboard provides a live visual table view — useful for ops, debugging, and verifying smoke tests without writing SQL.
+- Plain Postgres underneath: standard SQL, indexes, enums, and constraints all work as expected.
+- RLS is enabled on all tables. The bot uses `service_role` (bypasses RLS), but JWT-scoped policies can be added for mobile clients later using the reserved `supabase_auth_user_id` column — no schema changes required.
+- Multi-tenant isolation (`household_id` FK on every data table) is enforced at the application layer and can be enforced at the DB layer via RLS policies when the mobile app is added.
+
+**Negative / trade-offs:**
+- Supabase platform dependency: schema migrations, connection strings, and service role keys are managed in the Supabase console. If Supabase changes pricing or is acquired, migration effort is moderate (pure Postgres dump/restore, but the REST client would need replacing with a direct connection).
+- `service_role` key bypasses RLS entirely. This is intentional (server-side bot, never exposed to clients), but requires care: the key must never appear in client-side code or logs.
+- Supabase free tier projects pause after 1 week of inactivity. The always-on bot keeps the project active, but a deployment gap longer than 7 days would require manual unpausing.

--- a/docs/adr/ADR-004-in-memory-session-state.md
+++ b/docs/adr/ADR-004-in-memory-session-state.md
@@ -1,0 +1,39 @@
+# ADR-004: In-memory Maps for transient session state
+
+**Date:** April 2026  
+**Status:** Accepted
+
+## Context
+
+Two flows require short-lived per-user state that doesn't belong in the database:
+
+1. **Correction window** — after a task is added, the user has 10 minutes to send a correction. The bot needs to remember which task to correct and expire the window automatically.
+2. **Completion window** — after the daily cron posts the queue, the user has 2 hours to reply with completion status. The bot needs to remember which tasks were in today's queue.
+
+These windows are intentionally ephemeral. There is no need to reconstruct them after a restart — they are conversational state, not application state.
+
+## Decision
+
+Node.js in-memory `Map` objects with TTL-based expiry, implemented in `correction-session.js` and `queue-session.js`. Keys are `chatId:userId` (correction) and `telegramId` (queue). Expired entries are purged on each access and via a periodic sweep.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+|---|---|
+| Redis | Requires an additional hosted service. For 2–10 users and sessions measured in minutes, the operational overhead and cost of a Redis instance are not justified. |
+| Supabase (DB-backed sessions) | Every free-text message would trigger a DB read to check session state. Adds latency and couples a conversational concept to persistent storage, which complicates cleanup and TTL management. |
+| Telegraf session middleware (default in-memory or Supabase adapter) | The default in-memory adapter is not TTL-aware out of the box. The Supabase adapter has the same concerns as the option above. Our hand-rolled Maps give explicit control over TTL and key format. |
+| File-based session store | More complex than in-memory with no meaningful benefit at this scale. State still lost on restart. |
+
+## Consequences
+
+**Positive:**
+- Zero infrastructure overhead — no additional service to deploy, monitor, or pay for.
+- Sub-millisecond read/write — no async I/O for session lookups.
+- TTL behaviour is explicit and easy to reason about in tests.
+- The `startSessionForTask()` function in `correction-session.js` allows starting a correction session on *any* pending task (not just the most recently added), which enables the `/edit` command to reuse the same correction pipeline.
+
+**Negative / trade-offs:**
+- State is lost on process restart. If Railway restarts the bot mid-correction or mid-completion window, the session is gone. Users are unblocked by `/done <task>` and `/edit <task>` as explicit fallbacks, and this is documented in user guides.
+- No horizontal scaling. A second process instance would not share session state. Acceptable for a single-household bot on Railway; would require Redis if multiple processes were ever needed.
+- Memory grows with the number of active sessions. For 2–10 users with 10-minute and 2-hour windows, the maximum memory footprint is a few dozen Map entries — effectively zero.

--- a/docs/adr/ADR-005-google-calendar-template-url.md
+++ b/docs/adr/ADR-005-google-calendar-template-url.md
@@ -1,0 +1,38 @@
+# ADR-005: Google Calendar integration via TEMPLATE URL (no OAuth)
+
+**Date:** April 2026  
+**Status:** Accepted
+
+## Context
+
+The daily queue cron job posts a prioritised task list and a link to add it to Google Calendar as a timed work block. The UX goal is one tap from Telegram to a pre-filled calendar event — without the user needing to configure anything.
+
+Two approaches exist for creating Google Calendar events programmatically:
+1. Use the Google Calendar API (OAuth 2.0) to create events server-side
+2. Build a `https://calendar.google.com/calendar/render?action=TEMPLATE&...` URL that opens the pre-filled "create event" UI in the user's browser
+
+## Decision
+
+The TEMPLATE URL approach. No OAuth. No credentials. The bot constructs a URL with the event title, start/end time, and task list in the description field. The user taps the link, reviews the event, and saves it themselves.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+|---|---|
+| Google Calendar API (OAuth 2.0) | Requires each user to grant the bot OAuth access to their calendar. This introduces: an OAuth consent screen, refresh token storage per user, token expiry handling, and a Google Cloud project with Calendar API enabled. The event would be created silently (no user confirmation), which removes the chance to review before saving. Maintenance burden is high for a personal tool. |
+| Apple Calendar / CalDAV | Cross-platform support is fragmented. Requires per-user CalDAV credentials. Not viable as a primary integration. |
+| No calendar integration | Removing the only time-blocking mechanism leaves the queue as a list with no commitment to when the work happens. Time-boxing is a core part of the daily execution model. |
+
+## Consequences
+
+**Positive:**
+- Zero OAuth surface. No tokens to store, refresh, or rotate. No Google Cloud Console setup beyond enabling no APIs.
+- Works for any Google account without bot configuration — any household member can tap the link.
+- The event creation is always a conscious user action (tap → review → save), reducing accidental calendar pollution.
+- The URL is pure URL construction (`calendar.js` is a stateless pure function) — simple to test, impossible to break via API changes.
+
+**Negative / trade-offs:**
+- Event creation requires manual user action on every queue. If the user ignores the link, no event is created.
+- TEMPLATE URLs are not officially documented by Google as a stable API surface (though they have been stable for 10+ years). A Google UI change could break URL parameter handling.
+- The event description is plain text — no rich formatting, no task links. If tasks are updated after the calendar event is created, the event description will be stale.
+- One URL per household per day — it creates one block event with all tasks in the description, not individual events per task. This is by design (time-boxing, not scheduling).

--- a/docs/adr/ADR-006-multi-tenant-household-model.md
+++ b/docs/adr/ADR-006-multi-tenant-household-model.md
@@ -1,0 +1,57 @@
+# ADR-006: Multi-tenant household model with invite-based membership
+
+**Date:** April 2026  
+**Status:** Accepted  
+**Supersedes:** Original single-tenant design (flat `TELEGRAM_AUTHORISED_IDS` whitelist)
+
+## Context
+
+The initial design used a flat `TELEGRAM_AUTHORISED_IDS` env var: a comma-separated list of Telegram user IDs that were allowed to use the bot. This worked for a single family but had three problems:
+
+1. **Deployment coupling.** Adding a new user required a Railway env var change and a redeploy.
+2. **No isolation.** All authorised users shared the same tasks, areas, and settings. There was no way to run the same bot instance for two independent households.
+3. **No self-service.** Users could not join without an operator touching the server.
+
+The system needed to evolve to support multiple independent families on one deployment, each with their own isolated task list, areas, settings, and scheduler — without any operator involvement when a new family joins.
+
+## Decision
+
+A household-centric multi-tenant model:
+
+- **`households`** table is the tenant root. Each family is one household.
+- **`users`** table holds one row per Telegram identity, upserted on first contact.
+- **`household_members`** links users to households with a `role` (`admin` | `member`).
+- **`invite_codes`** table stores single-use, 24-hour-expiry codes generated with `crypto.randomBytes`. Codes are consumed atomically in the database (unique constraint on `used_at`).
+- All data tables (`tasks`, `areas`, `settings`) carry `household_id` as a foreign key. All application queries are scoped to it.
+- The `householdMiddleware` runs on every Telegram update, upserts the user, resolves membership, and attaches `ctx.household`, `ctx.householdUser`, and `ctx.memberRole`.
+- `requireMember()` and `requireAdmin()` middleware guards replace the old whitelist check.
+
+**Onboarding flow:**
+- First contact: `/start` → offer `/create` or `/join`
+- `/create <name>` → creates household, makes caller admin, seeds 12 default areas and one settings row
+- `/join <CODE>` → atomically consumes the invite code, inserts membership
+
+## Alternatives Considered
+
+| Option | Why rejected |
+|---|---|
+| Separate deployment per family | Operationally expensive. Each family requires its own Railway project, env vars, and Railway billing. Defeats the purpose of a shared codebase. |
+| Subdomain routing | Not applicable to Telegram bots — the Telegram Bot API routes to one bot token, not to subdomains. |
+| Hardcoded whitelist per household in env vars | Non-starter for self-service. Any new member requires an operator to redeploy. |
+| Shared task space with user tagging | Wrong isolation level. Two families on the same deployment would see each other's tasks. |
+| OAuth-based identity (Google/Apple) | Adds a mobile app dependency. The bot's strength is Telegram-only, no-install access. OAuth identity is reserved for a future mobile app via `supabase_auth_user_id`. |
+
+## Consequences
+
+**Positive:**
+- A single Railway deployment serves N families with zero operator involvement per new household.
+- Invite codes are stored in the DB, making them usable by a future mobile app (same code, same API).
+- The `supabase_auth_user_id` column on `users` is reserved for future JWT-based mobile auth without schema changes.
+- Per-household scheduler: each family fires their daily queue at their own configured time and timezone.
+- The `permissions` JSONB column on `settings` allows per-household access flags (e.g. area management admin-only) without schema changes.
+- RLS policies can be added per table to enforce household isolation at the DB layer when the mobile app is added — the `household_id` FK is already in place.
+
+**Negative / trade-offs:**
+- The `householdMiddleware` runs a DB upsert on *every* Telegram update, including commands from users who are not yet members. This is a small but real overhead that was not present in the whitelist design.
+- Bot startup now requires loading all households and initialising one cron job pair per household. A deployment with hundreds of households would need a more efficient scheduler bootstrap.
+- The multi-tenant schema migration from the single-tenant design requires a one-time backfill script (`scripts/migrate_to_multitenant.sql`), which must be run manually with household name and admin Telegram ID set as SQL variables.

--- a/docs/adr/ADR-007-one-household-per-user-v1.md
+++ b/docs/adr/ADR-007-one-household-per-user-v1.md
@@ -1,0 +1,44 @@
+# ADR-007: One household per user (v1 constraint)
+
+**Date:** April 2026  
+**Status:** Accepted
+
+## Context
+
+Once the multi-tenant model (ADR-006) allows multiple households to exist, there is a natural follow-on question: should a single user be allowed to belong to more than one household? For example, a user might want to be part of their own family's household and also their parents' household.
+
+The multi-tenant schema supports this theoretically — `household_members` could have multiple rows per user if the `UNIQUE(user_id)` constraint were dropped. However, multiple household membership creates a fundamental UX ambiguity:
+
+> When a user sends a free-text message ("fix the tap"), which household does it belong to?
+
+The bot cannot infer this from message content. The available resolution strategies are:
+1. Always ask ("Which household?") — destroys the zero-friction UX
+2. Infer from message content (AI-based routing) — unreliable and adds a classification step before classification
+3. Maintain an "active household" that the user can switch explicitly — viable but adds state and cognitive load
+
+## Decision
+
+Enforce `UNIQUE(user_id)` on `household_members`. In v1, a user belongs to exactly one household. Attempting to join a second household is rejected with a clear error message.
+
+The active household model has been designed and documented in `docs/multi-household-per-user-plan.md` for when this constraint is lifted.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+|---|---|
+| Active household model (`/switch <name>`) | Requires tracking `active_household_id` per user (either in-memory or DB). Every task card must show the household name as a safeguard against misfiled tasks. Adds `/switch` and `/myhouseholds` commands. Viable, but premature complexity for v1 where no real user has expressed this need yet. |
+| Always-ask routing | Introduces a confirmation step before every task capture. Eliminates the core UX value — frictionless capture. |
+| AI-based routing from message context | Requires an extra Gemini call per message to determine the target household. Unreliable when tasks are generic ("clean the kitchen"). |
+| No constraint (allow multiple, pick first) | Silently sends tasks to the wrong household. Confusing and hard to debug. |
+
+## Consequences
+
+**Positive:**
+- `householdMiddleware` is simple: one DB query, one resolved household, no `active_household_id` concept.
+- Task capture has zero ambiguity — every free-text message goes to the one household the user belongs to.
+- No `/switch` command needed. Fewer commands = simpler help text, simpler mental model.
+
+**Negative / trade-offs:**
+- A user who belongs to two households (e.g. own family + parents) cannot participate in both on the same bot instance. They would need to use two Telegram accounts, which is impractical.
+- Lifting this constraint later requires: dropping `UNIQUE(user_id)`, adding an `active_household_id` to users or in-memory state, modifying `householdMiddleware`, adding `/switch` + `/myhouseholds` commands, and updating all task cards to show the household name.
+- The design and schema changes required to lift this constraint are pre-documented in `docs/multi-household-per-user-plan.md`.

--- a/docs/adr/ADR-008-railway-hosting-long-polling.md
+++ b/docs/adr/ADR-008-railway-hosting-long-polling.md
@@ -1,0 +1,53 @@
+# ADR-008: Railway for hosting; long polling over webhook
+
+**Date:** April 2026  
+**Status:** Accepted
+
+## Context
+
+The bot needs to run continuously (not on-demand) because:
+- node-cron jobs for the daily queue and completion prompt must fire at configured times regardless of user activity
+- Correction and completion windows have time-based expiry driven by module-level timers
+
+A hosting platform is needed that keeps a Node.js process alive 24/7, deploys automatically from GitHub, and fits within a near-zero budget.
+
+Separately, Telegram bots can receive updates via two mechanisms:
+1. **Webhook** — Telegram POSTs updates to a public HTTPS endpoint on the bot's server
+2. **Long polling** — the bot repeatedly calls `getUpdates` with a timeout; Telegram holds the connection open until an update arrives
+
+## Decision
+
+**Hosting:** Railway.app with NIXPACKS auto-detection. The `railway.toml` sets the start command to `node src/bot.js`. Auto-deploy is triggered on push to `main`. Up to 10 restart retries on failure.
+
+**Update mechanism:** Long polling via Telegraf's default `bot.launch()` (no webhook configuration). The bot initiates connections to Telegram — Telegram never calls back.
+
+## Alternatives Considered
+
+**Hosting:**
+
+| Option | Why rejected |
+|---|---|
+| Render | Free tier spins down after 15 minutes of inactivity. Cron jobs would not fire reliably. |
+| Fly.io | Solid option, but Railway has a simpler GitHub deploy DX and adequate free credits. |
+| VPS (DigitalOcean/Hetzner) | Most control but requires OS management, SSL setup, and process supervision (PM2/systemd). Overkill for a personal bot. |
+| Serverless (Lambda/Cloud Functions) | Fundamentally incompatible with long-running processes and in-memory cron state. Would require external scheduling (EventBridge, Cloud Scheduler) and stateless handlers — a major architectural shift. |
+
+**Update mechanism:**
+
+| Option | Why rejected |
+|---|---|
+| Webhook | Requires a stable public HTTPS URL with a valid TLS certificate. Railway free tier does not guarantee a static IP or a reliable public hostname for webhook registration. Long polling avoids this entirely. |
+
+## Consequences
+
+**Positive:**
+- Railway provides always-on execution with GitHub auto-deploy on push to `main` — zero deployment ceremony.
+- Long polling requires no public IP, no TLS certificate management, and no webhook registration. Works from behind any NAT.
+- Railway's dashboard provides log streaming and restart monitoring — sufficient observability for a personal tool.
+- `railway.toml` pins the build configuration in the repo — deployment is reproducible.
+
+**Negative / trade-offs:**
+- Railway's free tier has changed in the past. If the always-on free tier is removed or capped, the monthly cost would be ~$1–2 (single small process). This is acceptable and was an explicit design constraint.
+- Long polling introduces ~1–2 seconds of additional latency per update compared to webhook delivery. For a home task bot this is imperceptible.
+- Long polling consumes one persistent outbound HTTP connection. At Railway scale this is irrelevant, but it is the reason webhook is preferred for high-throughput bots.
+- The in-process cron scheduler (node-cron) means cron jobs are tied to the Railway process lifecycle. A crash and restart during a queue-post or completion window loses the in-flight state (see ADR-004).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,61 @@
+# Architecture Decision Records
+
+This directory records significant architectural decisions made during the design and evolution of Home OS. Each ADR explains the context, the decision, the alternatives that were considered, and the consequences — so future contributors understand *why* the system is the way it is, not just *what* it does.
+
+## Status values
+
+| Status | Meaning |
+|---|---|
+| **Accepted** | Decision is in effect and reflected in the codebase |
+| **Superseded** | Decision has been replaced; see the superseding ADR |
+| **Deprecated** | Decision is being phased out |
+| **Proposed** | Under discussion, not yet implemented |
+
+## Index
+
+| ADR | Title | Status |
+|---|---|---|
+| [ADR-001](ADR-001-telegram-as-primary-interface.md) | Telegram as the sole user interface | Accepted |
+| [ADR-002](ADR-002-gemini-for-ai-classification.md) | Gemini 2.5 Flash for AI task classification | Accepted |
+| [ADR-003](ADR-003-supabase-for-persistence.md) | Supabase (managed Postgres) for persistence | Accepted |
+| [ADR-004](ADR-004-in-memory-session-state.md) | In-memory Maps for transient session state | Accepted |
+| [ADR-005](ADR-005-google-calendar-template-url.md) | Google Calendar integration via TEMPLATE URL | Accepted |
+| [ADR-006](ADR-006-multi-tenant-household-model.md) | Multi-tenant household model with invite codes | Accepted |
+| [ADR-007](ADR-007-one-household-per-user-v1.md) | One household per user (v1 constraint) | Accepted |
+| [ADR-008](ADR-008-railway-hosting-long-polling.md) | Railway for hosting; long polling over webhook | Accepted |
+
+## How to add an ADR
+
+1. Copy the template below into a new file: `ADR-NNN-short-title.md`
+2. Fill in all sections honestly — the *Consequences* section is the most important
+3. Add a row to the index above
+4. If the new decision supersedes an existing one, update the old ADR's status
+
+```markdown
+# ADR-NNN: Title
+
+**Date:** YYYY-MM  
+**Status:** Proposed | Accepted | Superseded by ADR-NNN | Deprecated
+
+## Context
+
+What situation or constraint forced this decision?
+
+## Decision
+
+What did we decide?
+
+## Alternatives Considered
+
+| Option | Why rejected |
+|---|---|
+| ... | ... |
+
+## Consequences
+
+**Positive:**
+- ...
+
+**Negative / trade-offs:**
+- ...
+```


### PR DESCRIPTION
## Summary

- Creates `docs/adr/` with 9 files: a README index and 8 ADRs
- No code changes — docs only

## ADRs included

| ADR | Decision |
|---|---|
| ADR-001 | Telegram as the sole interface — why not native app, web, or WhatsApp |
| ADR-002 | Gemini 2.5 Flash for AI classification — free tier, alternatives, rate limit trade-offs |
| ADR-003 | Supabase for persistence — vs Firebase/PlanetScale/SQLite, RLS forward-compatibility |
| ADR-004 | In-memory Maps for session state — vs Redis/Supabase, restart consequence documented |
| ADR-005 | Google Calendar via TEMPLATE URL — vs OAuth, intentional user-confirmation trade-off |
| ADR-006 | Multi-tenant household model — supersedes original TELEGRAM_AUTHORISED_IDS whitelist |
| ADR-007 | One household per user (v1 constraint) — ambiguity problem, path to lift documented |
| ADR-008 | Railway hosting + long polling — why not webhook, Render, or serverless |

## Test plan

- [ ] No code changes; no tests needed
- [ ] Verify `docs/adr/README.md` index links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)