### PR TITLE
Add ADRs: HomeOS architecture & analysis

### DIFF
--- a/docs/ar/AR-001.md
+++ b/docs/ar/AR-001.md
@@ -1,0 +1,209 @@
+# ADR Review: HomeOS Vision Alignment
+
+**Status:** Review / Proposed  
+**Date:** 2026-04-28  
+**Scope:** Assess current architecture against HomeOS vision; identify gaps and decisions needed
+
+---
+
+## Context
+
+The app is currently a **multi-tenant Telegram task manager** for families. The owner's vision is to evolve it into a true **HomeOS** — a natural-language companion that captures anything home-related and routes it to the right system: todo list, shopping list, bill/document repository, and calendar. Target scale is **thousands of households**.
+
+This review evaluates whether the current architecture can carry that vision or needs structural changes.
+
+---
+
+## What's Well-Aligned ✅
+
+| Area | Current State | Why It Holds |
+|------|--------------|--------------|
+| **Multi-tenancy** | `household_id` on all tables; invite codes; per-household cron | Already correct — scales to thousands of tenants with no schema change |
+| **AI as classifier** | Gemini classifies free text to structured task JSON | Pattern is right; needs to be extended, not replaced |
+| **Supabase** | PostgreSQL with RLS; `supabase_auth_user_id` reserved | Can host new entity tables (shopping, bills) with same tenant isolation |
+| **Telegram UX** | Natural language entry; free text → structured data | Natural fit for intent-agnostic capture |
+| **Modular handlers** | `handlers/`, `services/`, `middleware/` separation | Adding new entity types maps cleanly to new handler + service modules |
+| **Settings/permissions JSONB** | `permissions` column on settings table | Future access control without schema migration |
+
+---
+
+## Critical Gaps Against HomeOS Vision ❌
+
+### Gap 1 — No Intent Router (Biggest Structural Gap)
+
+**Current**: Every free-text message is assumed to be a **task** and routed directly to `classifyTask()` in Gemini.  
+**Vision needs**: AI must first determine *what kind of thing* is being captured — a todo task, a shopping item, a bill, or a document — then hand it to the appropriate handler.
+
+Without an intent router, adding shopping lists and bills means duplicating the classification flow and using heuristics rather than AI intent detection.
+
+**Decision needed**: Introduce a **meta-classifier** as the first step in `message.js`. A single Gemini call classifies intent as `task | shopping_item | bill | document | unknown`, then routes to the correct sub-handler. This is one additional AI call per message but is the correct separation.
+
+---
+
+### Gap 2 — Entity Model Is Task-Only
+
+**Current DB tables**: `tasks`, `areas`, `settings`, `households`, `users`, `household_members`, `invite_codes`  
+**Vision needs**: `shopping_items`, `bills` (with metadata), possibly `documents`
+
+**Decision needed**: Add new entity tables, all household-scoped:
+
+```sql
+-- shopping_items
+id, household_id, name, quantity, unit, category, store_preference,
+estimated_cost, added_by, purchased, purchased_at, purchased_by
+
+-- bills
+id, household_id, vendor, amount, currency, due_date, category,
+file_url, file_type, extracted_at, payment_task_id (FK → tasks),
+paid, paid_at, raw_input, notes
+```
+
+All queries follow same `household_id` scoping pattern already established.
+
+---
+
+### Gap 3 — No Document / Bill Storage
+
+**Vision**: Drop a photo of a bill → AI reads it → metadata stored → payment task created.  
+**Current**: Zero file handling. No Supabase Storage configuration. Gemini is called with text only.
+
+**Decision needed**: 
+- Enable **Supabase Storage** bucket `bills` (private, RLS-controlled)
+- Update Gemini calls for bills to use **multimodal input** (image/PDF bytes + prompt) via `@google/genai` (already supports this)
+- Extract: vendor, amount, due date, account number → store in `bills` table
+- Auto-create a `tasks` row (`pay {vendor} bill — due {date}`, `criticality: HIGH`, `assignedTo: Me`, `deadline: due_date - 3 days`)
+
+This is a **new service**: `src/services/bill-processor.js`
+
+---
+
+### Gap 4 — In-Memory Session State Won't Scale
+
+**Current**: Correction sessions (10-min TTL) and completion windows (2-hr TTL) are stored in **process memory** as JS Maps.  
+**Problem at scale**: If Railway runs 2+ instances (horizontal scaling), sessions are instance-local. A user whose session lands on instance A gets a broken experience if the next message hits instance B.
+
+**Decision needed**: Migrate session state to **Supabase** (simpler, already a dependency) or **Redis** (faster, purpose-built):
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Supabase sessions table | No new infra; already connected | Slightly higher latency; poll-based TTL |
+| Redis (Railway addon) | Purpose-built; atomic TTL; fast | New dependency; ~$5-10/mo |
+| Keep in-memory (v1) | Free; zero ops | Blocks horizontal scaling |
+
+**Recommendation**: Add a `sessions` table in Supabase now (low effort, no new infra), migrate in-memory Maps to DB-backed sessions. Adds ~20-50ms per session read but unblocks multi-instance deployment.
+
+```sql
+-- sessions
+id, household_id, telegram_user_id, type (correction|completion),
+payload (JSONB), expires_at, created_at
+```
+
+---
+
+### Gap 5 — Single-Process Scheduler Won't Scale
+
+**Current**: `Map<householdId, {queueJob, completionJob}>` — in-process cron for all households.  
+**Problem at scale**: 1,000 households = 2,000 cron jobs in one Node.js process. Memory and timing accuracy will degrade. Not distributable.
+
+**Decision needed**: At ~500+ households, extract scheduling to a **dedicated worker** or use **Supabase pg_cron** (native PostgreSQL scheduler):
+
+| Option | Notes |
+|--------|-------|
+| pg_cron (Supabase) | Run SQL-level jobs in DB; no extra process; mature |
+| Separate Railway worker | Independent Node process; full control |
+| Stay in-process (< 500 HH) | Fine for MVP scale; revisit at 500 |
+
+**Recommendation**: Stay in-process now. Add a `scheduled_jobs` table and switch to pg_cron when household count approaches 200-300. This is a **future ADR** — mark it as a known inflection point.
+
+---
+
+### Gap 6 — No Cross-Entity Workflows (Event-Driven Gap)
+
+**Vision**: Bill added → payment task auto-created. Task completed → shopping item auto-replenished (for recurring purchases). These are **cross-entity side effects**.
+
+**Current**: Handlers are purely request-response with no event/hook mechanism.
+
+**Decision needed**: Introduce a lightweight **internal event bus** (`src/events/bus.js`) — a simple `EventEmitter` wrapper:
+- `bill.created` → trigger `task.create` for payment
+- `task.completed` (with tag `needs-purchase`) → optionally prompt to add to shopping list
+
+This is in-process for now (Node.js EventEmitter). At scale it could be replaced with Supabase Realtime or a queue, but EventEmitter is zero-cost and compositional.
+
+---
+
+### Gap 7 — Shopping List Has No Purchase Workflow
+
+**Vision**: Shopping list items need to flow from "to buy" → "bought". This implies:
+- A `/shopping` command (view list)
+- A `/bought <item>` command
+- Optional: categorization (produce, pharmacy, hardware) for multi-store routing
+
+**Current**: No shopping concept exists. `needs-purchase` tag on tasks is a workaround.
+
+**Decision needed**: Implement shopping list as a first-class entity with a `/shopping` and `/bought` command pair. Reuse the `requireMember` guard and `household_id` scoping pattern exactly as tasks do.
+
+---
+
+## Recommended Architecture for HomeOS v2
+
+```
+Free-text message
+  → src/middleware/household.js            (unchanged)
+  → src/handlers/message.js               (UPDATED — intent routing gate)
+      → src/services/intent-classifier.js  (NEW — Gemini meta-classifier)
+          → "task"         → src/handlers/task.js       (renamed from message.js logic)
+          → "shopping"     → src/handlers/shopping.js   (NEW)
+          → "bill"         → src/handlers/bill.js       (NEW)
+              → src/services/bill-processor.js (NEW — multimodal Gemini + storage)
+              → src/services/task.js           (auto-create payment task)
+          → "document"     → src/handlers/document.js   (NEW, future)
+          → "unknown"      → ask for clarification
+
+  → src/services/supabase.js              (EXTENDED — new tables)
+  → src/events/bus.js                     (NEW — cross-entity side effects)
+```
+
+**New DB tables**: `shopping_items`, `bills`, `sessions`  
+**New Supabase Storage bucket**: `bills`  
+**New services**: `intent-classifier.js`, `bill-processor.js`  
+**New handlers**: `shopping.js`, `bill.js`  
+**Updated handlers**: `message.js` (becomes router only), `task.js` (renamed from current task logic)
+
+---
+
+## Decision Summary
+
+| # | Decision | Urgency | Effort |
+|---|----------|---------|--------|
+| 1 | Add intent-classifier meta-classifier before routing | **Before shipping new entities** | M |
+| 2 | Add `shopping_items` and `bills` DB tables | **Before shopping/bill features** | S |
+| 3 | Enable Supabase Storage for bill files | **For bill capture** | S |
+| 4 | Add multimodal Gemini bill extraction service | **For bill capture** | M |
+| 5 | Migrate in-memory sessions to Supabase `sessions` table | **Before horizontal scaling** | M |
+| 6 | Add internal EventEmitter bus for cross-entity workflows | **Before bill → task auto-create** | S |
+| 7 | Implement `/shopping` + `/bought` commands | **For shopping list feature** | M |
+| 8 | Mark in-process scheduler as a scale inflection point (revisit at 200 HH) | Future ADR | S |
+
+---
+
+## What This ADR Does NOT Change
+
+- Telegram as the primary UX surface (correct for now)
+- Supabase as the database (correct)
+- Gemini as the AI engine (correct)
+- Railway as deployment (correct for current scale)
+- Multi-tenancy patterns (household_id, guards, invite codes) — these are solid
+- Node.js + Telegraf stack — no reason to change
+
+---
+
+## Verification
+
+Once implemented:
+1. Send a shopping item in free text ("need to buy milk") → should land in shopping list, not tasks
+2. Send a task ("fix the leaking tap") → should land in tasks as before
+3. Send/upload a bill → should extract metadata, store file, and auto-create a payment task
+4. `/shopping` → shows pending shopping items
+5. `/bought milk` → marks milk purchased
+6. Kill and restart the bot mid-correction-session → session should survive (Supabase sessions)
+7. Run `npm test` → all 218 existing tests pass; new entity tests added

--- a/docs/ar/AR-002.md
+++ b/docs/ar/AR-002.md
@@ -1,0 +1,304 @@
+# HomeOS — Deep Architectural Analysis
+
+**Date:** 2026-04-28  
+**Type:** Strategic review — not an implementation plan
+
+---
+
+## 1. Gemini Reliability & Scaling
+
+### The Real Problem
+
+The "service overloaded" 503 errors are from hitting the **Gemini Free tier rate limits** (15 req/min, 1,500 req/day on Flash 2.5). At a few dozen active households making several captures a day, you'll hit this regularly during peak hours.
+
+The current code has **no retry logic** — one failure = user-facing error.
+
+### Immediate Fix (costs nothing)
+
+Add **exponential backoff with jitter** around every Gemini call:
+
+```
+Attempt 1 → fail → wait 1s
+Attempt 2 → fail → wait 2s  
+Attempt 3 → fail → wait 4s → surface error to user
+```
+
+This alone eliminates ~80% of visible errors since transient 503s clear within seconds.
+
+### Cost Reality at Scale
+
+| Stage | Households | AI calls/day | Gemini 2.5 Flash cost/mo |
+|-------|-----------|--------------|--------------------------|
+| Now | <50 | <500 | Free |
+| Growth | 500 | ~5,000 | ~$1.50/mo |
+| Scale | 5,000 | ~50,000 | ~$15/mo |
+| Serious | 50,000 | ~500,000 | ~$150/mo |
+
+**AI cost is not your problem.** At every stage, it's less than your Railway hosting bill. The concern is **reliability**, not cost.
+
+### AI Provider Options (Cost-Conscious Ranking)
+
+| Provider | Model | Price (input/1M) | Reliability | Notes |
+|----------|-------|-----------------|-------------|-------|
+| **Gemini** | 2.5 Flash | $0.075 | Medium | Current; free tier fragile |
+| **Groq** | Llama 3.3 70B | $0.59 | High | Extremely fast inference; no free tier but cheap |
+| **OpenAI** | GPT-4o-mini | $0.15 | Very high | Best reliability track record |
+| **Claude** | Haiku 4.5 | $0.25 | Very high | Best instruction-following for structured JSON |
+| **OpenRouter** | Any | Variable | High | Meta-router: pick cheapest with auto-fallback |
+
+### Recommended Strategy
+
+**Phase 1 (now):** Stay on Gemini Free + add retry/backoff + add a **rule-based fallback classifier** (regex on keywords: "buy", "shopping", "bill", "fix", "repair" → intent type). If Gemini is down, rule-based still works for obvious cases.
+
+**Phase 2 (at 200+ households):** Move to Gemini **Paid tier** (~$10/mo top-up). Eliminates rate limit errors entirely for the foreseeable future.
+
+**Phase 3 (if reliability still a concern):** Use **OpenRouter** as a provider wrapper. Single API key routes to Gemini primary → Claude Haiku fallback → GPT-4o-mini secondary. Cost stays nearly identical; reliability becomes excellent.
+
+**Never do:** Build your own LLM infrastructure. The cost/complexity is not justified until $50k+/mo AI spend.
+
+---
+
+## 2. Telegram vs. App — Interface Strategy
+
+### The Honest Assessment
+
+Telegram is **the right choice right now** and will remain the right primary capture interface for longer than you might think. Here's why:
+
+**What Telegram does better than any app you'd build:**
+- Zero install friction (share a link, they're in)
+- Push notifications that actually get seen (unlike app push which gets disabled)
+- Works on every device, every OS, offline-capable
+- Group chat = family coordination built-in
+- Voice messages (which you can transcribe via Gemini later)
+- File sharing (photos of bills, receipts)
+
+### User Persona Analysis
+
+**Primary user (you):** Tech-forward, high trust in AI, wants power and speed. Telegram is perfect.
+
+**Spouse / family member:** The make-or-break user. If they have to install an app, set up an account, and learn a new UI, **you lose them**. Telegram they already have. That's the moat.
+
+**Future paying user:** Busy household manager, 28-45, dual-income family, overwhelmed. They want one place to dump everything. They do NOT want to context-switch to an app. **Telegram as universal inbox is the right positioning.**
+
+### When You'll Actually Need an App
+
+| Trigger | What You Need | When |
+|---------|--------------|------|
+| Users want to browse tasks visually | Web app (read-only dashboard) | 300-500 users |
+| Monetization (subscriptions) | Stripe + web billing page | First paying customer |
+| Non-Telegram users (significant segment) | WhatsApp bot OR web app | Depends on market |
+| Rich document viewing (bills, receipts) | Web app | 500+ users |
+| B2B / property management angle | Full web app + API | Strategic pivot point |
+
+### The Hybrid Model (Recommended)
+
+```
+Telegram = Capture + Notification layer (always)
+Web app  = View + Manage + Billing layer (when needed)
+```
+
+This is exactly what the `supabase_auth_user_id` column anticipates. The architecture is already positioned for it.
+
+**The web app doesn't have to be big:** A clean read-only dashboard showing tasks, shopping list, bills — with Stripe checkout for subscriptions — is 80% of the value. 2-3 weeks of work when the time comes.
+
+### Monetization on Telegram (Before You Build an App)
+
+- **Telegram Stars** (Telegram's built-in payment system) — can sell premium features
+- **External Stripe link** in bot messages — "Upgrade to Pro →" button that opens Stripe checkout in browser
+- **Freemium model:** Free = 30 tasks/month + 1 member. Pro = unlimited + shopping + bills + 5 members. **No app needed for this.**
+
+### Do NOT build a mobile app early
+
+A native iOS/Android app before product-market fit is a trap:
+- 3-6 months of work
+- App store approval friction
+- Maintenance overhead doubles
+- Pushes monetization further out
+
+**The path:** Telegram → web app → mobile app (if ever needed). Many successful SaaS products never need a native app.
+
+---
+
+## 3. Node.js — Right Choice for Long Term?
+
+### Short Answer: Yes, with one caveat
+
+Node.js is well-suited for what this bot does — it's almost entirely **I/O bound work**: waiting on Telegram API, Gemini API, Supabase queries. Node's event loop is optimal for exactly this pattern. You're not doing CPU-heavy computation.
+
+### What's Actually Right About the Stack
+
+| Choice | Verdict | Reason |
+|--------|---------|--------|
+| Node.js | ✅ Keep | I/O bound workload; large ecosystem; JS unification if web app added |
+| Telegraf | ✅ Keep | Mature, well-maintained Telegram framework |
+| Supabase | ✅ Keep | Postgres + auth + storage + realtime in one; RLS for multi-tenancy |
+| Railway | ✅ Keep (for now) | Cheap, simple; migrate to Fly.io or Render when you need more control |
+| Long-polling | ⚠️ Switch | Webhooks are more reliable and efficient at scale (trivial change) |
+
+### The One Real Risk: No TypeScript
+
+Plain JavaScript becomes painful when you have:
+- 5+ entity types with different schemas
+- Multiple developers
+- Complex AI response parsing (Gemini returns JSON you trust without type checks)
+
+**Recommendation:** Don't migrate now. Add TypeScript when you add the second major entity type (shopping or bills). The migration is straightforward with modern tooling.
+
+### Scaling Path for Node
+
+| Stage | What to Do |
+|-------|-----------|
+| Now (< 200 HH) | Single instance, long-polling, in-memory sessions |
+| 200-500 HH | Switch to webhooks; migrate sessions to Supabase |
+| 500-2000 HH | 2-3 Railway instances behind load balancer; pg_cron for scheduling |
+| 2000+ HH | Dedicated worker for AI calls (queue-based); CDN for static assets |
+
+Node.js handles all of these stages fine. The stack is not your bottleneck.
+
+### What Would Make You Switch Languages
+
+You'd only consider switching if:
+1. You needed **real-time high-frequency data processing** (not applicable)
+2. You had a **Python-native ML pipeline** you were integrating deeply (not applicable — you use Gemini API)
+3. You needed extreme **throughput efficiency** at massive scale (not applicable until 100k+ households)
+
+Go or Rust would give you better performance/memory, but the development velocity cost is not worth it for a solo/small team product.
+
+---
+
+## 4. Other Architectural Decisions for Serious Long-Term Value
+
+### A. Capture Philosophy — Keep This Sacred
+
+The core value proposition of HomeOS is **zero-friction capture from one place**. Every architectural decision should be tested against: "Does this make capture harder?"
+
+This means:
+- The `/` command list should never exceed ~10 user-facing commands (hide complexity in AI routing)
+- Adding a feature should NEVER add a new command if the AI can infer intent
+- The bot reply to a capture should be **1 message, fast** (< 2 seconds end-to-end)
+
+### B. Billing Architecture (for Monetization)
+
+Add a `plan` column to `households` table now:
+```sql
+ALTER TABLE households ADD COLUMN plan TEXT NOT NULL DEFAULT 'free';
+-- 'free' | 'pro' | 'family' | 'lifetime'
+```
+
+Add usage tracking:
+```sql
+CREATE TABLE usage_metrics (
+  household_id UUID REFERENCES households,
+  month DATE,  -- truncated to first of month
+  ai_calls INT DEFAULT 0,
+  tasks_created INT DEFAULT 0,
+  shopping_items INT DEFAULT 0,
+  bills_processed INT DEFAULT 0
+);
+```
+
+Gate features in middleware:
+```js
+// src/middleware/plan.js
+if (ctx.household.plan === 'free' && usageThisMonth.tasks > 30) {
+  return ctx.reply('You\'ve hit the free limit. Upgrade to Pro →');
+}
+```
+
+**Freemium tiers (suggested):**
+
+| Feature | Free | Pro ($4.99/mo) | Family ($9.99/mo) |
+|---------|------|----------------|-------------------|
+| Tasks | 30/month | Unlimited | Unlimited |
+| Shopping list | ❌ | ✅ | ✅ |
+| Bill capture | ❌ | ✅ | ✅ |
+| Members | 2 | 2 | 5 |
+| Daily queue | ✅ | ✅ | ✅ |
+
+### C. Long-Polling → Webhooks (Do This Soon)
+
+Long-polling works but:
+- Keeps an open HTTP connection to Telegram servers at all times
+- Less efficient, slower message delivery
+- Doesn't scale across multiple instances (only one poller can run)
+
+Webhooks: Telegram pushes to your Railway HTTPS endpoint. Scales naturally. Takes ~30 minutes to implement with Telegraf.
+
+```js
+// Instead of bot.launch() with long-poll:
+await bot.telegram.setWebhook(`https://your-railway-app.railway.app/bot`);
+app.post('/bot', (req, res) => bot.handleUpdate(req.body, res));
+```
+
+### D. Observability — Minimum Viable
+
+You currently have structured JSON logs. Before you have paying users, add:
+
+1. **Sentry** (free tier) — catches unhandled exceptions with stack traces. 10-minute setup.
+2. **One business metric** — log to a `events` table: `{ household_id, event_type, created_at }`. Types: `task_created`, `bill_captured`, `queue_sent`, `member_joined`. This gives you retention and engagement data without a third-party analytics tool.
+
+### E. Data Export / GDPR (Small Effort, High Trust)
+
+Add `/export` command → generates a JSON or CSV of all household data → sends as file via Telegram. This:
+- Satisfies GDPR right to portability (required for EU users)
+- Builds trust ("we don't lock you in")
+- Takes ~2 hours to implement
+
+### F. The "No Clutter" Rule for Feature Additions
+
+Every feature request should pass this test before building:
+
+1. **Does it require a new command?** If yes, can AI routing absorb it instead?
+2. **Does it serve the core capture → action → done loop?** If it's a dashboard/analytics feature, defer to the web app phase.
+3. **Does it help the family member (not just the power user)?** If only the admin benefits, lower priority.
+
+**Stick to the "3 verbs per entity" rule:**
+- Tasks: add (AI) → `/pending` → `/done`
+- Shopping: add (AI) → `/shopping` → `/bought`
+- Bills: add (AI/photo) → `/bills` → `/paid`
+
+### G. Voice Notes (High Value, Low Effort to Design)
+
+Telegram supports voice messages natively. Gemini 2.0+ supports audio input. The pipeline:
+
+```
+Voice note → Telegram sends audio file URL → download → send bytes to Gemini
+→ "transcribe + classify intent + extract entity" in one call
+→ same routing as text
+```
+
+This is a **massive UX differentiator** — "just voice-note your HomeOS while cooking." No other home management tool does this well. Medium effort to build, high user value.
+
+### H. Multi-Channel Input (Don't Build Yet, Design For)
+
+Future inputs that the architecture should accommodate without rewrites:
+- **Email forwarding** (forward a bill email → parsed and stored)
+- **WhatsApp** (via Twilio or Meta API — same intent classifier, different transport)
+- **Web form** (for non-Telegram users in the household)
+- **Zapier / Make integration** (power users automate captures from other apps)
+
+The architecture supports this because the intent classifier and entity services are **transport-agnostic**. Only the handler layer is Telegram-specific.
+
+---
+
+## Summary Decision Matrix
+
+| Decision | Do Now | Do at 200 HH | Do at 500 HH | Never |
+|----------|--------|-------------|--------------|-------|
+| Retry + backoff on Gemini | ✅ | — | — | — |
+| Rule-based fallback classifier | ✅ | — | — | — |
+| Long-polling → webhooks | ✅ | — | — | — |
+| Add `plan` column to households | ✅ | — | — | — |
+| Sentry error tracking | ✅ | — | — | — |
+| GDPR `/export` command | ✅ | — | — | — |
+| Intent router (Gap 1 from ADR) | ✅ | — | — | — |
+| Sessions → Supabase (Gap 4) | — | ✅ | — | — |
+| Gemini paid tier | — | ✅ | — | — |
+| TypeScript migration | — | ✅ | — | — |
+| Web app (dashboard + billing) | — | ✅ | — | — |
+| Voice note support | — | ✅ | — | — |
+| Scheduler → pg_cron (Gap 5) | — | — | ✅ | — |
+| OpenRouter multi-provider | — | — | ✅ | — |
+| Native mobile app | — | — | — | Until $500k ARR |
+| Self-hosted LLM | — | — | — | ✅ Never |
+| Switch from Node.js | — | — | — | ✅ Never |


### PR DESCRIPTION
Add two architecture decision records: docs/ar/AR-001.md (HomeOS vision alignment review) and docs/ar/AR-002.md (deep architectural analysis). AR-001 recommends an intent meta-classifier, new entity tables (shopping_items, bills, sessions), Supabase Storage for bills, a multimodal bill-processor service, DB-backed sessions, an internal event bus, and shopping/bought handlers; it also flags scheduler pg_cron as an inflection point. AR-002 covers Gemini reliability (retry/backoff, rule-based fallback, provider options), long-poll → webhook recommendation, billing/plan and usage metrics, observability, GDPR export, voice-note strategy, and a staged scaling roadmap.