### PR TITLE
feat: Phase 1 — Gemini retry + backoff

### DIFF
--- a/src/handlers/message.js
+++ b/src/handlers/message.js
@@ -57,7 +57,12 @@ async function handleMessage(ctx) {
     setRecentTask(ctx.chat.id, ctx.from.id, { ...task, id: taskId });
   } catch (err) {
     error("task_capture_failed", { message: err.message, userId, householdId: ctx.household.id });
-    await ctx.reply("⚠️ Something went wrong. Try rephrasing?");
+    const isAiOverload = err.status === 503 || err.status === 429;
+    await ctx.reply(
+      isAiOverload
+        ? "⚠️ AI is temporarily overloaded. Try again in a moment."
+        : "⚠️ Something went wrong. Try rephrasing?"
+    );
   }
 }
 

--- a/src/services/gemini.js
+++ b/src/services/gemini.js
@@ -8,6 +8,7 @@ const {
   normalizeTags,
   safeParseJsonObject
 } = require("../utils/validators");
+const { withRetry } = require("../utils/retry");
 
 const client = new GoogleGenAI({ apiKey: config.geminiApiKey });
 
@@ -120,10 +121,10 @@ function sanitizePatch(rawPatch) {
 }
 
 async function generateJson(prompt) {
-  const response = await client.models.generateContent({
-    model: config.geminiModel,
-    contents: prompt
-  });
+  const response = await withRetry(
+    () => client.models.generateContent({ model: config.geminiModel, contents: prompt }),
+    { retryOn: [503, 429], maxAttempts: 3, baseDelayMs: 1000 }
+  );
   const text = response.text || "";
   const parsed = safeParseJsonObject(text);
   if (!parsed) {

--- a/src/utils/retry.js
+++ b/src/utils/retry.js
@@ -1,0 +1,25 @@
+'use strict';
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function withRetry(fn, { retryOn = [503, 429], maxAttempts = 3, baseDelayMs = 1000, _sleep = sleep } = {}) {
+  let lastError;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const status = err.status ?? err.statusCode ?? err.response?.status;
+      if (!retryOn.includes(status)) throw err;
+      lastError = err;
+      if (attempt < maxAttempts - 1) {
+        const delay = baseDelayMs * Math.pow(2, attempt) + Math.random() * 500;
+        await _sleep(delay);
+      }
+    }
+  }
+  throw lastError;
+}
+
+module.exports = { withRetry };

--- a/test/handlers/message.test.js
+++ b/test/handlers/message.test.js
@@ -172,11 +172,37 @@ describe('handleMessage', () => {
     assert.ok(ctx.reply.mock.calls[0].arguments[0].includes('Balcony'));
   });
 
-  it('replies with error message when classifyTask throws', async () => {
+  it('replies with generic error message when classifyTask throws an error without a status', async () => {
     classifyTask.mock.mockImplementation(async () => { throw new Error('Gemini error'); });
     const ctx = makeCtx('fix tap');
     await handleMessage(ctx);
     assert.equal(ctx.reply.mock.calls.length, 1);
     assert.ok(ctx.reply.mock.calls[0].arguments[0].includes('went wrong'));
+  });
+
+  it('replies with AI overload message when classifyTask throws a 503 error', async () => {
+    const overloadErr = new Error('Service overloaded');
+    overloadErr.status = 503;
+    classifyTask.mock.mockImplementation(async () => { throw overloadErr; });
+    const ctx = makeCtx('fix tap');
+    await handleMessage(ctx);
+    assert.equal(ctx.reply.mock.calls.length, 1);
+    assert.ok(
+      ctx.reply.mock.calls[0].arguments[0].includes('temporarily overloaded'),
+      'should mention temporarily overloaded'
+    );
+  });
+
+  it('replies with AI overload message when classifyTask throws a 429 error', async () => {
+    const rateLimitErr = new Error('Rate limited');
+    rateLimitErr.status = 429;
+    classifyTask.mock.mockImplementation(async () => { throw rateLimitErr; });
+    const ctx = makeCtx('fix tap');
+    await handleMessage(ctx);
+    assert.equal(ctx.reply.mock.calls.length, 1);
+    assert.ok(
+      ctx.reply.mock.calls[0].arguments[0].includes('temporarily overloaded'),
+      'should mention temporarily overloaded'
+    );
   });
 });

--- a/test/unit/gemini.test.js
+++ b/test/unit/gemini.test.js
@@ -1,0 +1,96 @@
+'use strict';
+const { describe, it, mock, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+// Mock withRetry as a pass-through so tests run without delays
+const withRetry = mock.fn(async (fn) => fn());
+require.cache[require.resolve('../../src/utils/retry')] = {
+  exports: { withRetry }
+};
+
+// Mock config
+require.cache[require.resolve('../../src/config')] = {
+  exports: { config: { geminiApiKey: 'fake-key', geminiModel: 'gemini-2.5-flash' } }
+};
+
+// Mock @google/genai
+const generateContent = mock.fn(async () => ({
+  text: '{"title":"Fix tap","area":"Kitchen","isNewArea":false,"criticality":"HIGH","effortMins":30,"tags":[],"assignedTo":"Me","deadline":null,"reasoning":"Dripping.","isRecurring":false,"recurrenceIntervalDays":null,"nextDueDate":null}'
+}));
+require.cache[require.resolve('@google/genai')] = {
+  exports: {
+    GoogleGenAI: class {
+      get models() { return { generateContent }; }
+    }
+  }
+};
+
+const { classifyTask, correctTask } = require('../../src/services/gemini');
+
+describe('classifyTask', () => {
+  beforeEach(() => {
+    withRetry.mock.resetCalls();
+    generateContent.mock.resetCalls();
+    withRetry.mock.mockImplementation(async (fn) => fn());
+    generateContent.mock.mockImplementation(async () => ({
+      text: '{"title":"Fix tap","area":"Kitchen","isNewArea":false,"criticality":"HIGH","effortMins":30,"tags":[],"assignedTo":"Me","deadline":null,"reasoning":"Dripping.","isRecurring":false,"recurrenceIntervalDays":null,"nextDueDate":null}'
+    }));
+  });
+
+  it('calls withRetry wrapping the generateContent call', async () => {
+    await classifyTask('fix the tap', ['Kitchen']);
+    assert.equal(withRetry.mock.calls.length, 1);
+  });
+
+  it('returns a sanitized task with correct fields', async () => {
+    const task = await classifyTask('fix the tap', ['Kitchen']);
+    assert.equal(task.title, 'Fix tap');
+    assert.equal(task.area, 'Kitchen');
+    assert.equal(task.criticality, 'HIGH');
+    assert.equal(task.effortMins, 30);
+    assert.equal(task.assignedTo, 'Me');
+    assert.equal(task.isNewArea, false);
+  });
+
+  it('marks isNewArea true when area is not in the known list', async () => {
+    generateContent.mock.mockImplementation(async () => ({
+      text: '{"title":"Fix balcony door","area":"Balcony","isNewArea":true,"criticality":"MEDIUM","effortMins":20,"tags":[],"assignedTo":"Me","deadline":null,"reasoning":"ok.","isRecurring":false,"recurrenceIntervalDays":null,"nextDueDate":null}'
+    }));
+    const task = await classifyTask('fix balcony door', ['Kitchen', 'Bathroom']);
+    assert.equal(task.isNewArea, true);
+    assert.equal(task.area, 'Balcony');
+  });
+
+  it('propagates the error when withRetry exhausts', async () => {
+    const overloadErr = new Error('Service overloaded');
+    overloadErr.status = 503;
+    withRetry.mock.mockImplementation(async () => { throw overloadErr; });
+    await assert.rejects(() => classifyTask('fix tap', ['Kitchen']), { message: 'Service overloaded' });
+  });
+
+  it('throws when Gemini returns invalid JSON', async () => {
+    generateContent.mock.mockImplementation(async () => ({ text: 'not json' }));
+    await assert.rejects(() => classifyTask('fix tap', ['Kitchen']), { message: 'Gemini returned invalid JSON.' });
+  });
+});
+
+describe('correctTask', () => {
+  beforeEach(() => {
+    withRetry.mock.resetCalls();
+    generateContent.mock.resetCalls();
+    withRetry.mock.mockImplementation(async (fn) => fn());
+  });
+
+  it('calls withRetry wrapping the generateContent call', async () => {
+    generateContent.mock.mockImplementation(async () => ({ text: '{"criticality":"HIGH"}' }));
+    await correctTask({ title: 'Fix tap', criticality: 'MEDIUM' }, 'make it HIGH');
+    assert.equal(withRetry.mock.calls.length, 1);
+  });
+
+  it('returns a sanitized patch with only the changed field', async () => {
+    generateContent.mock.mockImplementation(async () => ({ text: '{"criticality":"HIGH"}' }));
+    const patch = await correctTask({ title: 'Fix tap', criticality: 'MEDIUM' }, 'make it HIGH');
+    assert.equal(patch.criticality, 'HIGH');
+    assert.equal(Object.keys(patch).length, 1);
+  });
+});

--- a/test/unit/retry.test.js
+++ b/test/unit/retry.test.js
@@ -1,0 +1,115 @@
+'use strict';
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { withRetry } = require('../../src/utils/retry');
+
+const noSleep = () => Promise.resolve();
+
+function makeErr(status) {
+  const err = new Error(`HTTP ${status}`);
+  err.status = status;
+  return err;
+}
+
+describe('withRetry', () => {
+  it('resolves immediately when fn succeeds on first attempt', async () => {
+    const result = await withRetry(async () => 'ok', { _sleep: noSleep });
+    assert.equal(result, 'ok');
+  });
+
+  it('retries on 503 and resolves when fn eventually succeeds', async () => {
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      if (calls < 3) throw makeErr(503);
+      return 'ok';
+    };
+    const result = await withRetry(fn, { _sleep: noSleep });
+    assert.equal(result, 'ok');
+    assert.equal(calls, 3);
+  });
+
+  it('retries on 429 and resolves when fn eventually succeeds', async () => {
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      if (calls < 2) throw makeErr(429);
+      return 'done';
+    };
+    const result = await withRetry(fn, { _sleep: noSleep });
+    assert.equal(result, 'done');
+    assert.equal(calls, 2);
+  });
+
+  it('does not retry on 400 — throws immediately after one attempt', async () => {
+    let calls = 0;
+    const fn = async () => { calls++; throw makeErr(400); };
+    await assert.rejects(() => withRetry(fn, { _sleep: noSleep }), { message: 'HTTP 400' });
+    assert.equal(calls, 1);
+  });
+
+  it('does not retry on 401 — throws immediately after one attempt', async () => {
+    let calls = 0;
+    const fn = async () => { calls++; throw makeErr(401); };
+    await assert.rejects(() => withRetry(fn, { _sleep: noSleep }), { message: 'HTTP 401' });
+    assert.equal(calls, 1);
+  });
+
+  it('does not retry on errors with no status', async () => {
+    let calls = 0;
+    const fn = async () => { calls++; throw new Error('network'); };
+    await assert.rejects(() => withRetry(fn, { _sleep: noSleep }), { message: 'network' });
+    assert.equal(calls, 1);
+  });
+
+  it('throws last error after exhausting maxAttempts', async () => {
+    let calls = 0;
+    const fn = async () => { calls++; throw makeErr(503); };
+    await assert.rejects(() => withRetry(fn, { maxAttempts: 3, _sleep: noSleep }), { message: 'HTTP 503' });
+    assert.equal(calls, 3);
+  });
+
+  it('respects custom maxAttempts', async () => {
+    let calls = 0;
+    const fn = async () => { calls++; throw makeErr(503); };
+    await assert.rejects(() => withRetry(fn, { maxAttempts: 2, _sleep: noSleep }));
+    assert.equal(calls, 2);
+  });
+
+  it('respects custom retryOn list', async () => {
+    let calls = 0;
+    const fn = async () => { calls++; throw makeErr(500); };
+    await assert.rejects(() => withRetry(fn, { retryOn: [500], maxAttempts: 2, _sleep: noSleep }));
+    assert.equal(calls, 2);
+  });
+
+  it('reads status from err.statusCode when err.status is absent', async () => {
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      if (calls < 2) {
+        const err = new Error('retry');
+        err.statusCode = 503;
+        throw err;
+      }
+      return 'ok';
+    };
+    const result = await withRetry(fn, { _sleep: noSleep });
+    assert.equal(result, 'ok');
+  });
+
+  it('calls _sleep between retries with increasing delays', async () => {
+    const sleepCalls = [];
+    const fakeSleep = (ms) => { sleepCalls.push(ms); return Promise.resolve(); };
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      if (calls < 3) throw makeErr(503);
+      return 'ok';
+    };
+    await withRetry(fn, { maxAttempts: 3, baseDelayMs: 100, _sleep: fakeSleep });
+    assert.equal(sleepCalls.length, 2);
+    assert.ok(sleepCalls[0] >= 100, 'first delay >= baseDelayMs');
+    assert.ok(sleepCalls[1] >= 200, 'second delay >= 2x baseDelayMs');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a generic `withRetry(fn, options)` utility with exponential backoff + jitter, retrying only on 503/429
- Wires `withRetry` into `generateJson` in the Gemini service (3 attempts, 1s base delay)
- Distinguishes AI-overload errors (503/429) from other failures in the message handler, showing `"⚠️ AI is temporarily overloaded. Try again in a moment."` instead of the misleading "try rephrasing" message

## Test plan

- [ ] `node --test test/unit/retry.test.js` — 11 tests covering retry, no-retry, exhaustion, backoff, statusCode fallback
- [ ] `node --test test/unit/gemini.test.js` — 7 tests covering retry wiring, sanitized output, error propagation
- [ ] `node --test test/handlers/message.test.js` — 13 tests including 2 new overload error path tests
- [ ] `npm test` — 242 tests, 0 failures

## Notes

- `withRetry` accepts an injectable `_sleep` parameter so tests run without real delays
- `baseDelayMs` is hardcoded at 1000ms in `generateJson` — worst-case user wait on 3 failures is ~7s
- Phase 2 (fallback classifier) will build on this by catching retry exhaustion in `classifyTask` and returning a default task instead of propagating the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)