### PR TITLE
feat: Phase 2 — Rule-based fallback classifier

### DIFF
--- a/src/handlers/message.js
+++ b/src/handlers/message.js
@@ -39,7 +39,7 @@ async function handleMessage(ctx) {
 
   try {
     const areas = await getAreas(ctx.household.id);
-    const task = await classifyTask(incoming, areas);
+    const { _isFallback, ...task } = await classifyTask(incoming, areas);
     const taskId = await createTask(ctx.household.id, {
       ...task,
       rawInput: incoming,
@@ -52,8 +52,12 @@ async function handleMessage(ctx) {
     }
 
     const block = `🏠 ${ctx.household.name}\n\n${formatTaskCard({ ...task, id: taskId })}`;
-    const witty = await generateWittyReply('task_added', { title: task.title, area: task.area, assignedTo: task.assignedTo });
-    await ctx.reply(witty ? `${block}\n\n${witty}` : block);
+    if (_isFallback) {
+      await ctx.reply(`${block}\n\n⚠️ AI unavailable — saved with defaults. Reply 'correct' to adjust.`);
+    } else {
+      const witty = await generateWittyReply('task_added', { title: task.title, area: task.area, assignedTo: task.assignedTo });
+      await ctx.reply(witty ? `${block}\n\n${witty}` : block);
+    }
     setRecentTask(ctx.chat.id, ctx.from.id, { ...task, id: taskId });
   } catch (err) {
     error("task_capture_failed", { message: err.message, userId, householdId: ctx.household.id });

--- a/src/services/gemini.js
+++ b/src/services/gemini.js
@@ -134,8 +134,29 @@ async function generateJson(prompt) {
 }
 
 async function classifyTask(text, areas) {
-  const raw = await generateJson(buildClassificationPrompt(text, areas));
-  return sanitizeTask(raw, areas, text);
+  try {
+    const raw = await generateJson(buildClassificationPrompt(text, areas));
+    return sanitizeTask(raw, areas, text);
+  } catch (err) {
+    if (err.status === 503 || err.status === 429) {
+      return {
+        title: String(text).trim() || "Untitled task",
+        area: "General",
+        isNewArea: false,
+        criticality: "MEDIUM",
+        effortMins: 30,
+        tags: [],
+        assignedTo: "Me",
+        deadline: null,
+        reasoning: "",
+        isRecurring: false,
+        recurrenceIntervalDays: null,
+        nextDueDate: null,
+        _isFallback: true
+      };
+    }
+    throw err;
+  }
 }
 
 async function correctTask(existingTask, correctionText) {

--- a/test/handlers/message.test.js
+++ b/test/handlers/message.test.js
@@ -205,4 +205,51 @@ describe('handleMessage', () => {
       'should mention temporarily overloaded'
     );
   });
+
+  it('shows fallback banner when classifyTask returns _isFallback task', async () => {
+    classifyTask.mock.mockImplementation(async () => ({
+      title: 'fix the leaky tap', area: 'General', criticality: 'MEDIUM',
+      effortMins: 30, assignedTo: 'Me', tags: [], reasoning: '', isNewArea: false,
+      isRecurring: false, recurrenceIntervalDays: null, nextDueDate: null,
+      _isFallback: true
+    }));
+    const ctx = makeCtx('fix the leaky tap');
+    await handleMessage(ctx);
+    assert.equal(ctx.reply.mock.calls.length, 1);
+    assert.ok(
+      ctx.reply.mock.calls[0].arguments[0].includes('AI unavailable'),
+      'reply should include AI unavailable banner'
+    );
+    assert.ok(
+      ctx.reply.mock.calls[0].arguments[0].includes("Reply 'correct'"),
+      'reply should prompt user to correct'
+    );
+  });
+
+  it('does not pass _isFallback to createTask', async () => {
+    classifyTask.mock.mockImplementation(async () => ({
+      title: 'fix the leaky tap', area: 'General', criticality: 'MEDIUM',
+      effortMins: 30, assignedTo: 'Me', tags: [], reasoning: '', isNewArea: false,
+      isRecurring: false, recurrenceIntervalDays: null, nextDueDate: null,
+      _isFallback: true
+    }));
+    const ctx = makeCtx('fix the leaky tap');
+    await handleMessage(ctx);
+    const taskArg = createTask.mock.calls[0].arguments[1];
+    assert.equal(taskArg._isFallback, undefined);
+  });
+
+  it('skips witty reply and still saves task when fallback is active', async () => {
+    classifyTask.mock.mockImplementation(async () => ({
+      title: 'buy milk', area: 'General', criticality: 'MEDIUM',
+      effortMins: 30, assignedTo: 'Me', tags: [], reasoning: '', isNewArea: false,
+      isRecurring: false, recurrenceIntervalDays: null, nextDueDate: null,
+      _isFallback: true
+    }));
+    const ctx = makeCtx('buy milk');
+    await handleMessage(ctx);
+    assert.equal(createTask.mock.calls.length, 1);
+    assert.equal(setRecentTask.mock.calls.length, 1);
+    assert.equal(ctx.reply.mock.calls.length, 1);
+  });
 });

--- a/test/unit/gemini.test.js
+++ b/test/unit/gemini.test.js
@@ -61,11 +61,33 @@ describe('classifyTask', () => {
     assert.equal(task.area, 'Balcony');
   });
 
-  it('propagates the error when withRetry exhausts', async () => {
+  it('returns a fallback task when withRetry exhausts on 503', async () => {
     const overloadErr = new Error('Service overloaded');
     overloadErr.status = 503;
     withRetry.mock.mockImplementation(async () => { throw overloadErr; });
-    await assert.rejects(() => classifyTask('fix tap', ['Kitchen']), { message: 'Service overloaded' });
+    const task = await classifyTask('fix the leaky tap', ['Kitchen']);
+    assert.equal(task.title, 'fix the leaky tap');
+    assert.equal(task.area, 'General');
+    assert.equal(task.criticality, 'MEDIUM');
+    assert.equal(task.effortMins, 30);
+    assert.equal(task.isNewArea, false);
+    assert.equal(task._isFallback, true);
+  });
+
+  it('returns a fallback task when withRetry exhausts on 429', async () => {
+    const rateLimitErr = new Error('Rate limited');
+    rateLimitErr.status = 429;
+    withRetry.mock.mockImplementation(async () => { throw rateLimitErr; });
+    const task = await classifyTask('buy milk', ['Kitchen']);
+    assert.equal(task._isFallback, true);
+    assert.equal(task.title, 'buy milk');
+  });
+
+  it('still propagates non-overload errors from withRetry', async () => {
+    const badKeyErr = new Error('Invalid API key');
+    badKeyErr.status = 401;
+    withRetry.mock.mockImplementation(async () => { throw badKeyErr; });
+    await assert.rejects(() => classifyTask('fix tap', ['Kitchen']), { message: 'Invalid API key' });
   });
 
   it('throws when Gemini returns invalid JSON', async () => {


### PR DESCRIPTION
## Summary

- `classifyTask` now catches 503/429 errors from exhausted retries and returns a safe default task (`_isFallback: true`) instead of throwing — inputs are never lost when AI is down
- `message.js` strips `_isFallback` before persisting to DB, skips the witty reply, and appends the fallback banner: `"⚠️ AI unavailable — saved with defaults. Reply 'correct' to adjust."`
- Existing correction flow works unchanged — user can immediately correct the classification

## Test plan

- [ ] `node --test test/unit/gemini.test.js` — 3 new tests: fallback on 503, fallback on 429, non-overload errors still propagate
- [ ] `node --test test/handlers/message.test.js` — 3 new tests: fallback banner shown, `_isFallback` stripped from `createTask`, task still saved and session set
- [ ] `npm test` — 247 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)