### PR TITLE
feat: Phase 3 — Sentry error tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ GEMINI_MODEL=gemini-2.5-flash
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=
 COMPLETION_PROMPT_DELAY_MINS=30
+
+# Optional: Sentry error tracking. If absent, Sentry is silently disabled.
+SENTRY_DSN=

--- a/src/bot.js
+++ b/src/bot.js
@@ -8,6 +8,9 @@ const { handleMessage } = require("./handlers/message");
 const { purgeExpiredSessions } = require("./handlers/correction-session");
 const { startScheduler } = require("./cron/scheduler");
 const { info, error } = require("./utils/logger");
+const { initSentry } = require("./services/sentry");
+
+initSentry();
 
 const bot = new Telegraf(config.telegramBotToken);
 

--- a/src/cron/scheduler.js
+++ b/src/cron/scheduler.js
@@ -10,6 +10,7 @@ const {
 } = require("../services/supabase");
 const { formatQueueMessage } = require("../utils/formatters");
 const { info, error } = require("../utils/logger");
+const { captureException } = require("../services/sentry");
 const { config } = require("../config");
 const { setQueuedTasks, startCompletionWindow } = require("../handlers/queue-session");
 
@@ -68,6 +69,7 @@ function scheduleForHousehold(bot, household) {
         });
       } catch (err) {
         error("queue_post_failed", { householdId: household.id, message: err.message });
+        captureException(err, { operation: 'queue_post', householdId: household.id });
       }
     },
     { timezone }
@@ -88,6 +90,7 @@ function scheduleForHousehold(bot, household) {
         info("completion_prompt_sent", { householdId: household.id, audienceCount: members.length });
       } catch (err) {
         error("completion_prompt_failed", { householdId: household.id, message: err.message });
+        captureException(err, { operation: 'completion_prompt', householdId: household.id });
       }
     },
     { timezone }

--- a/src/handlers/message.js
+++ b/src/handlers/message.js
@@ -3,6 +3,7 @@ const { generateWittyReply } = require("../services/witty-response");
 const { addArea, createTask, getAreas } = require("../services/supabase");
 const { formatTaskCard } = require("../utils/formatters");
 const { error } = require("../utils/logger");
+const { captureException } = require("../services/sentry");
 const { handleCorrection } = require("./correction");
 const { getSession, setRecentTask, startSession } = require("./correction-session");
 const { handleCompletionReply } = require("./complete");
@@ -61,6 +62,7 @@ async function handleMessage(ctx) {
     setRecentTask(ctx.chat.id, ctx.from.id, { ...task, id: taskId });
   } catch (err) {
     error("task_capture_failed", { message: err.message, userId, householdId: ctx.household.id });
+    captureException(err, { operation: 'task_capture', householdId: ctx.household.id });
     const isAiOverload = err.status === 503 || err.status === 429;
     await ctx.reply(
       isAiOverload

--- a/src/services/gemini.js
+++ b/src/services/gemini.js
@@ -9,6 +9,7 @@ const {
   safeParseJsonObject
 } = require("../utils/validators");
 const { withRetry } = require("../utils/retry");
+const { captureException } = require("./sentry");
 
 const client = new GoogleGenAI({ apiKey: config.geminiApiKey });
 
@@ -139,6 +140,7 @@ async function classifyTask(text, areas) {
     return sanitizeTask(raw, areas, text);
   } catch (err) {
     if (err.status === 503 || err.status === 429) {
+      captureException(err, { operation: 'classifyTask', inputLength: String(text).length });
       return {
         title: String(text).trim() || "Untitled task",
         area: "General",

--- a/src/services/sentry.js
+++ b/src/services/sentry.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const Sentry = require('@sentry/node');
+
+let initialised = false;
+
+function initSentry() {
+  const dsn = process.env.SENTRY_DSN;
+  if (!dsn) return;
+  Sentry.init({ dsn, environment: process.env.NODE_ENV || 'production' });
+  initialised = true;
+}
+
+function captureException(err, context) {
+  if (!initialised) return;
+  Sentry.captureException(err, context ? { extra: context } : undefined);
+}
+
+module.exports = { initSentry, captureException };

--- a/test/unit/sentry.test.js
+++ b/test/unit/sentry.test.js
@@ -1,0 +1,81 @@
+'use strict';
+const { describe, it, mock, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const sentryInit = mock.fn();
+const sentryCaptureException = mock.fn();
+
+require.cache[require.resolve('@sentry/node')] = {
+  exports: {
+    init: sentryInit,
+    captureException: sentryCaptureException
+  }
+};
+
+// Load fresh module for each describe block by deleting cache between groups
+function loadFreshSentry() {
+  delete require.cache[require.resolve('../../src/services/sentry')];
+  return require('../../src/services/sentry');
+}
+
+describe('initSentry — with DSN', () => {
+  beforeEach(() => {
+    sentryInit.mock.resetCalls();
+    sentryCaptureException.mock.resetCalls();
+    delete require.cache[require.resolve('../../src/services/sentry')];
+    process.env.SENTRY_DSN = 'https://fake@sentry.io/123';
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    delete process.env.SENTRY_DSN;
+  });
+
+  it('calls Sentry.init with dsn and environment when DSN is present', () => {
+    const { initSentry } = loadFreshSentry();
+    initSentry();
+    assert.equal(sentryInit.mock.calls.length, 1);
+    const opts = sentryInit.mock.calls[0].arguments[0];
+    assert.equal(opts.dsn, 'https://fake@sentry.io/123');
+    assert.equal(opts.environment, 'test');
+  });
+
+  it('captureException delegates to Sentry after init', () => {
+    const { initSentry, captureException } = loadFreshSentry();
+    initSentry();
+    const err = new Error('boom');
+    captureException(err, { householdId: 'h1' });
+    assert.equal(sentryCaptureException.mock.calls.length, 1);
+    assert.equal(sentryCaptureException.mock.calls[0].arguments[0], err);
+  });
+
+  it('captureException passes context as extra when provided', () => {
+    const { initSentry, captureException } = loadFreshSentry();
+    initSentry();
+    captureException(new Error('x'), { householdId: 'h2', operation: 'queue' });
+    const callArgs = sentryCaptureException.mock.calls[0].arguments;
+    assert.deepEqual(callArgs[1], { extra: { householdId: 'h2', operation: 'queue' } });
+  });
+});
+
+describe('initSentry — without DSN', () => {
+  beforeEach(() => {
+    sentryInit.mock.resetCalls();
+    sentryCaptureException.mock.resetCalls();
+    delete require.cache[require.resolve('../../src/services/sentry')];
+    delete process.env.SENTRY_DSN;
+  });
+
+  it('does not call Sentry.init when DSN is absent', () => {
+    const { initSentry } = loadFreshSentry();
+    initSentry();
+    assert.equal(sentryInit.mock.calls.length, 0);
+  });
+
+  it('captureException is a no-op when DSN is absent', () => {
+    const { initSentry, captureException } = loadFreshSentry();
+    initSentry();
+    assert.doesNotThrow(() => captureException(new Error('ignored')));
+    assert.equal(sentryCaptureException.mock.calls.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary

- New `src/services/sentry.js` — `initSentry()` reads `SENTRY_DSN` (optional); silently no-ops if absent; tags `NODE_ENV` as environment. `captureException(err, context)` delegates to Sentry only after init.
- `initSentry()` called once at bot startup in `bot.js`
- Explicit `captureException` calls added at:
  - `gemini.js` — Gemini retry exhaustion (503/429 fallback path), with `operation` and `inputLength`
  - `message.js` — task capture catch block, with `operation` and `householdId`
  - `scheduler.js` — queue post failure and completion prompt failure, both with `operation` and `householdId`
- `SENTRY_DSN=` added to `.env.example` with comment

## Test plan

- [ ] `node --test test/unit/sentry.test.js` — 5 tests: init with DSN calls Sentry.init, context passed as extra, no-op when DSN absent, captureException no-op when not initialised
- [ ] `npm test` — 252 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)