### PR TITLE
Phase 4: webhook transport in production, long-poll in dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ COMPLETION_PROMPT_DELAY_MINS=30
 
 # Optional: Sentry error tracking. If absent, Sentry is silently disabled.
 SENTRY_DSN=
+
+# Optional: Webhook URL for production. If absent, bot uses long-polling (development mode).
+WEBHOOK_URL=

--- a/src/bot.js
+++ b/src/bot.js
@@ -9,6 +9,7 @@ const { purgeExpiredSessions } = require("./handlers/correction-session");
 const { startScheduler } = require("./cron/scheduler");
 const { info, error } = require("./utils/logger");
 const { initSentry } = require("./services/sentry");
+const { launchBot } = require("./utils/launch-bot");
 
 initSentry();
 
@@ -44,7 +45,7 @@ registerAdminCommands(bot);
 registerCommands(bot)
   .then(async () => {
     await startScheduler(bot);
-    return bot.launch();
+    return launchBot(bot, config, process.env);
   })
   .then(() => info("bot_started"))
   .catch((err) => {

--- a/src/config.js
+++ b/src/config.js
@@ -41,7 +41,8 @@ const config = {
   geminiModel: parseGeminiModel(process.env.GEMINI_MODEL),
   supabaseUrl: requireEnv("SUPABASE_URL"),
   supabaseServiceRoleKey: requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
-  completionPromptDelayMins: parseDuration(process.env.COMPLETION_PROMPT_DELAY_MINS)
+  completionPromptDelayMins: parseDuration(process.env.COMPLETION_PROMPT_DELAY_MINS),
+  webhookUrl: process.env.WEBHOOK_URL?.trim() || null
 };
 
 module.exports = {

--- a/src/utils/launch-bot.js
+++ b/src/utils/launch-bot.js
@@ -1,0 +1,13 @@
+'use strict';
+
+async function launchBot(bot, cfg, env) {
+  if (cfg.webhookUrl && env.NODE_ENV === 'production') {
+    await bot.launch({
+      webhook: { domain: cfg.webhookUrl, port: parseInt(env.PORT || '3000', 10) }
+    });
+  } else {
+    await bot.launch();
+  }
+}
+
+module.exports = { launchBot };

--- a/test/unit/launch-bot.test.js
+++ b/test/unit/launch-bot.test.js
@@ -1,0 +1,48 @@
+'use strict';
+const { describe, it, mock } = require('node:test');
+const assert = require('node:assert/strict');
+
+// launchBot is a pure function — takes (bot, config, env) as explicit args
+// No require.cache mocking needed
+const { launchBot } = require('../../src/utils/launch-bot');
+
+describe('launchBot — production with webhookUrl', () => {
+  it('calls bot.launch with webhook config when NODE_ENV=production and webhookUrl is set', async () => {
+    const bot = { launch: mock.fn(async () => {}) };
+    const cfg = { webhookUrl: 'https://example.com' };
+    const env = { NODE_ENV: 'production', PORT: '3000' };
+
+    await launchBot(bot, cfg, env);
+
+    assert.equal(bot.launch.mock.calls.length, 1);
+    assert.deepEqual(bot.launch.mock.calls[0].arguments[0], {
+      webhook: { domain: 'https://example.com', port: 3000 }
+    });
+  });
+});
+
+describe('launchBot — development with no webhookUrl', () => {
+  it('calls bot.launch with no args when NODE_ENV=development and webhookUrl is null', async () => {
+    const bot = { launch: mock.fn(async () => {}) };
+    const cfg = { webhookUrl: null };
+    const env = { NODE_ENV: 'development' };
+
+    await launchBot(bot, cfg, env);
+
+    assert.equal(bot.launch.mock.calls.length, 1);
+    assert.equal(bot.launch.mock.calls[0].arguments.length, 0);
+  });
+});
+
+describe('launchBot — production but no webhookUrl', () => {
+  it('falls back to long-poll when NODE_ENV=production but webhookUrl is null', async () => {
+    const bot = { launch: mock.fn(async () => {}) };
+    const cfg = { webhookUrl: null };
+    const env = { NODE_ENV: 'production' };
+
+    await launchBot(bot, cfg, env);
+
+    assert.equal(bot.launch.mock.calls.length, 1);
+    assert.equal(bot.launch.mock.calls[0].arguments.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts `launchBot(bot, cfg, env)` into `src/utils/launch-bot.js` — pure function, no side effects
- Uses webhooks when `NODE_ENV=production` and `WEBHOOK_URL` is set; falls back to long-poll otherwise
- Wires `webhookUrl` into `src/config.js` as an optional field (null when absent)
- Documents `WEBHOOK_URL` in `.env.example`
- `src/bot.js` now calls `launchBot(bot, config, process.env)` instead of `bot.launch()` directly

## Test plan
- [ ] `test/unit/launch-bot.test.js` — 3 scenarios: production+URL, dev+null, production+null fallback
- [ ] Full suite `node --test test/` — 255 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)