### PR TITLE
Phase 5: plan column on households (defaults to free)

### DIFF
--- a/scripts/add_plan_column.sql
+++ b/scripts/add_plan_column.sql
@@ -1,0 +1,6 @@
+-- Phase 5: Add plan column to households
+-- Run this in the Supabase SQL Editor for existing deployments.
+-- New deployments should include this in create_schema.sql instead.
+
+ALTER TABLE households
+  ADD COLUMN IF NOT EXISTS plan TEXT NOT NULL DEFAULT 'free';

--- a/src/services/supabase.js
+++ b/src/services/supabase.js
@@ -242,7 +242,7 @@ async function createHousehold(name, adminUserId) {
   const { data: household, error: hError } = await supabase
     .from("households")
     .insert({ name })
-    .select("id, name")
+    .select("id, name, plan")
     .single();
   if (hError) throw hError;
 
@@ -260,7 +260,7 @@ async function createHousehold(name, adminUserId) {
 async function getHousehold(householdId) {
   const { data, error } = await supabase
     .from("households")
-    .select("id, name")
+    .select("id, name, plan")
     .eq("id", householdId)
     .single();
   if (error) throw error;
@@ -272,7 +272,7 @@ async function getAllHouseholdsWithSettings() {
   // so PostgREST embeds it as an array; we take [0] since UNIQUE(household_id).
   const { data, error } = await supabase
     .from("households")
-    .select("id, name, settings(calendar_time, calendar_duration, timezone)")
+    .select("id, name, plan, settings(calendar_time, calendar_duration, timezone)")
     .is("deleted_at", null);
   if (error) throw error;
   return data
@@ -288,6 +288,7 @@ async function getAllHouseholdsWithSettings() {
       return {
         id: h.id,
         name: h.name,
+        plan: h.plan || "free",
         settings: {
           calendarTime: s.calendar_time.slice(0, 5),
           calendarDuration: s.calendar_duration,

--- a/test/unit/supabase.test.js
+++ b/test/unit/supabase.test.js
@@ -53,7 +53,7 @@ require.cache[require.resolve('../../src/utils/logger')] = {
   exports: { info: mock.fn(), warn: warnFn, error: mock.fn() }
 };
 
-const { bulkComplete, getIncompleteTasksByPriority, getAllHouseholdsWithSettings } = require('../../src/services/supabase');
+const { bulkComplete, getIncompleteTasksByPriority, getAllHouseholdsWithSettings, getHousehold } = require('../../src/services/supabase');
 
 // ─── bulkComplete ─────────────────────────────────────────────────────────────
 
@@ -255,5 +255,41 @@ describe('getAllHouseholdsWithSettings', () => {
     const result = await getAllHouseholdsWithSettings();
     assert.equal(result.length, 0);
     assert.equal(warnFn.mock.calls.length, 2);
+  });
+
+  it('includes plan field on each returned household', async () => {
+    responseQueue.push({
+      data: [{
+        id: 'h1', name: 'Sharma House', plan: 'free',
+        settings: [{ calendar_time: '18:00:00', calendar_duration: 60, timezone: 'Asia/Kolkata' }]
+      }],
+      error: null
+    });
+    const result = await getAllHouseholdsWithSettings();
+    assert.equal(result.length, 1);
+    assert.equal(result[0].plan, 'free');
+  });
+});
+
+// ─── getHousehold ─────────────────────────────────────────────────────────────
+
+describe('getHousehold', () => {
+  beforeEach(() => {
+    responseQueue = [];
+    warnFn.mock.resetCalls();
+  });
+
+  it('returns id, name, and plan from the DB row', async () => {
+    responseQueue.push({ data: { id: 'h1', name: 'Sharma House', plan: 'free' }, error: null });
+    const result = await getHousehold('h1');
+    assert.equal(result.id, 'h1');
+    assert.equal(result.name, 'Sharma House');
+    assert.equal(result.plan, 'free');
+  });
+
+  it('passes through non-default plan values', async () => {
+    responseQueue.push({ data: { id: 'h2', name: 'Pro House', plan: 'pro' }, error: null });
+    const result = await getHousehold('h2');
+    assert.equal(result.plan, 'pro');
   });
 });


### PR DESCRIPTION
## Summary
- Adds `plan TEXT NOT NULL DEFAULT 'free'` to `households` via `scripts/add_plan_column.sql`
- `getHousehold` selects and returns the `plan` field
- `getAllHouseholdsWithSettings` includes `plan` on each mapped household
- `createHousehold` selects `plan` in the insert response
- No feature gating — column only, ready for future use

## Migration
Run `scripts/add_plan_column.sql` in the Supabase SQL Editor for existing deployments.

## Test plan
- [ ] 3 new tests in `test/unit/supabase.test.js` covering `plan` field propagation
- [ ] Full suite `node --test test/` — 258 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)