### PR TITLE
Phase 6: /export command — full household JSON via sendDocument

### DIFF
--- a/src/handlers/commands.js
+++ b/src/handlers/commands.js
@@ -19,6 +19,7 @@ const { parseDurationMinutes, parseTimeHHMM, parseTimezone } = require("../utils
 const { error } = require("../utils/logger");
 const { generateWittyReply } = require("../services/witty-response");
 const { startSessionForTask } = require("./correction-session");
+const { buildExportPayload } = require("../services/export");
 
 function householdHeader(name) {
   return `🏠 ${name}\n\n`;
@@ -169,6 +170,15 @@ async function registerCommands(bot) {
     await ctx.reply(witty || `✅ Timezone set to ${tz}`);
   }));
 
+  bot.command("export", requireMember(async (ctx) => {
+    const payload = await buildExportPayload(ctx.household.id);
+    const json = JSON.stringify(payload, null, 2);
+    await ctx.replyWithDocument({
+      source: Buffer.from(json, 'utf8'),
+      filename: 'export.json'
+    });
+  }));
+
   bot.command("help", requireMember(async (ctx) => {
     const isAdmin = ctx.memberRole === "admin";
     const lines = [
@@ -186,6 +196,7 @@ async function registerCommands(bot) {
       "/edit <number or name> — edit a task's details",
       "/settings — show settings",
       "/leavehousehold — leave this household",
+      "/export — download all your household data as JSON",
       "/help — this message"
     ];
     if (isAdmin) {

--- a/src/services/export.js
+++ b/src/services/export.js
@@ -1,0 +1,22 @@
+'use strict';
+const { getAllTasks, getAreas, getSettings, getHouseholdMembers, getHousehold } = require('./supabase');
+
+async function buildExportPayload(householdId) {
+  const [household, tasks, areas, settings, members] = await Promise.all([
+    getHousehold(householdId),
+    getAllTasks(householdId),
+    getAreas(householdId),
+    getSettings(householdId),
+    getHouseholdMembers(householdId)
+  ]);
+  return {
+    exportedAt: new Date().toISOString(),
+    household,
+    tasks,
+    areas,
+    settings,
+    members
+  };
+}
+
+module.exports = { buildExportPayload };

--- a/src/services/supabase.js
+++ b/src/services/supabase.js
@@ -106,6 +106,16 @@ async function getIncompleteTasksByPriority(householdId) {
     });
 }
 
+async function getAllTasks(householdId) {
+  const { data, error } = await supabase
+    .from("tasks")
+    .select("*")
+    .eq("household_id", householdId)
+    .order("created_at", { ascending: true });
+  if (error) throw error;
+  return data.map(fromDbTask);
+}
+
 async function bulkComplete(ids) {
   if (!ids.length) return 0;
   const now = new Date().toISOString();
@@ -445,6 +455,7 @@ module.exports = {
   // Tasks
   createTask,
   updateTask,
+  getAllTasks,
   getIncompleteTasksByPriority,
   bulkComplete,
   deleteTask,

--- a/test/handlers/commands.test.js
+++ b/test/handlers/commands.test.js
@@ -15,9 +15,20 @@ const updateSettings = mock.fn(async () => {});
 
 const refreshScheduleForHousehold = mock.fn(async () => {});
 const startSessionForTask = mock.fn();
+const buildExportPayload = mock.fn(async () => ({
+  exportedAt: '2026-05-01T00:00:00.000Z',
+  household: { id: 'h1', name: 'The Sharma House', plan: 'free' },
+  tasks: [],
+  areas: [],
+  settings: { calendarTime: '18:00', calendarDuration: 60, timezone: 'Asia/Kolkata' },
+  members: []
+}));
 
 require.cache[require.resolve('../../src/services/supabase')] = {
   exports: { getAreas, addArea, removeArea, bulkComplete, deleteTask, getHouseholdMembers, getMembership, getIncompleteTasksByPriority, getSettings, updateSettings }
+};
+require.cache[require.resolve('../../src/services/export')] = {
+  exports: { buildExportPayload }
 };
 require.cache[require.resolve('../../src/cron/scheduler')] = {
   exports: { refreshScheduleForHousehold }
@@ -72,6 +83,7 @@ describe('commands', () => {
     updateSettings.mock.resetCalls();
     refreshScheduleForHousehold.mock.resetCalls();
     startSessionForTask.mock.resetCalls();
+    buildExportPayload.mock.resetCalls();
 
     getAreas.mock.mockImplementation(async () => []);
     getHouseholdMembers.mock.mockImplementation(async () => []);
@@ -375,6 +387,25 @@ describe('commands', () => {
       const ctx = makeCtx('/help');
       await handlers['help'](ctx);
       assert.ok(ctx.reply.mock.calls[0].arguments[0].includes('The Sharma House'));
+    });
+  });
+
+  describe('/export', () => {
+    it('sends a JSON document with all household data', async () => {
+      const replyWithDocument = mock.fn(async () => {});
+      const ctx = makeCtx('/export', { replyWithDocument });
+      await handlers['export'](ctx);
+
+      assert.equal(buildExportPayload.mock.calls.length, 1);
+      assert.equal(buildExportPayload.mock.calls[0].arguments[0], 'h1');
+
+      assert.equal(replyWithDocument.mock.calls.length, 1);
+      const [doc] = replyWithDocument.mock.calls[0].arguments;
+      assert.equal(doc.filename, 'export.json');
+      assert.ok(Buffer.isBuffer(doc.source), 'source should be a Buffer');
+
+      const parsed = JSON.parse(doc.source.toString('utf8'));
+      assert.equal(parsed.household.name, 'The Sharma House');
     });
   });
 });

--- a/test/unit/export.test.js
+++ b/test/unit/export.test.js
@@ -1,0 +1,46 @@
+'use strict';
+const { describe, it, mock } = require('node:test');
+const assert = require('node:assert/strict');
+
+const getAllTasks = mock.fn(async () => []);
+const getAreas = mock.fn(async () => []);
+const getSettings = mock.fn(async () => ({ calendarTime: '18:00', calendarDuration: 60, timezone: 'Asia/Kolkata' }));
+const getHouseholdMembers = mock.fn(async () => []);
+const getHousehold = mock.fn(async () => ({ id: 'h1', name: 'Sharma House', plan: 'free' }));
+
+require.cache[require.resolve('../../src/services/supabase')] = {
+  exports: { getAllTasks, getAreas, getSettings, getHouseholdMembers, getHousehold }
+};
+
+const { buildExportPayload } = require('../../src/services/export');
+
+describe('buildExportPayload', () => {
+  it('returns an object with household, tasks, areas, settings, and members keys', async () => {
+    const payload = await buildExportPayload('h1');
+    assert.ok('household' in payload, 'missing household');
+    assert.ok('tasks' in payload, 'missing tasks');
+    assert.ok('areas' in payload, 'missing areas');
+    assert.ok('settings' in payload, 'missing settings');
+    assert.ok('members' in payload, 'missing members');
+    assert.ok('exportedAt' in payload, 'missing exportedAt');
+  });
+
+  it('includes household name and plan', async () => {
+    getHousehold.mock.mockImplementation(async () => ({ id: 'h1', name: 'Sharma House', plan: 'pro' }));
+    const payload = await buildExportPayload('h1');
+    assert.equal(payload.household.name, 'Sharma House');
+    assert.equal(payload.household.plan, 'pro');
+  });
+
+  it('includes all tasks returned by getAllTasks', async () => {
+    const tasks = [{ id: 't1', title: 'Fix sink', criticality: 'HIGH' }];
+    getAllTasks.mock.mockImplementation(async () => tasks);
+    const payload = await buildExportPayload('h1');
+    assert.deepEqual(payload.tasks, tasks);
+  });
+
+  it('exportedAt is an ISO date string', async () => {
+    const payload = await buildExportPayload('h1');
+    assert.ok(!isNaN(Date.parse(payload.exportedAt)), 'exportedAt is not a valid date');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `/export` command (member-accessible) that gathers all household data and sends it as `export.json` via `replyWithDocument`
- Adds `getAllTasks(householdId)` to `supabase.js` — fetches all tasks (complete + incomplete) for GDPR completeness
- Adds `src/services/export.js` with `buildExportPayload(householdId)` — pure async function, easy to test
- Export includes: household info, all tasks, areas, settings, members, and `exportedAt` timestamp
- `/help` updated to document the new command

## Migration
No schema changes required.

## Test plan
- [ ] `test/unit/export.test.js` — 4 tests for `buildExportPayload` shape and field correctness
- [ ] `test/handlers/commands.test.js` — 1 test verifying Buffer sent with correct filename and parseable JSON
- [ ] Full suite `node --test test/` — 263 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)