### PR TITLE
Phase 7: intent router shell — 9 intents, stubs for non-task flows

### DIFF
--- a/src/handlers/message.js
+++ b/src/handlers/message.js
@@ -8,6 +8,17 @@ const { handleCorrection } = require("./correction");
 const { getSession, setRecentTask, startSession } = require("./correction-session");
 const { handleCompletionReply } = require("./complete");
 const { isCompletionWindowActive } = require("./queue-session");
+const { classifyIntent } = require("../services/intent-classifier");
+
+const INTENT_STUBS = {
+  note:       '📝 Note-taking is coming soon. For now, save this as a task.',
+  reminder:   '⏰ Reminders are coming soon.',
+  contact:    '👤 Contact management is coming soon.',
+  expense:    '💰 Expense tracking is coming soon.',
+  question:   '❓ Q&A is coming soon. Use /pending or /queue to check your tasks.',
+  correction: '✏️ To correct the last task, type "correct" or "fix this".',
+  completion: '✅ To mark tasks done after your daily queue, reply yes / skip <task> / no.'
+};
 
 async function handleMessage(ctx) {
   if (!ctx.household) return;
@@ -35,6 +46,12 @@ async function handleMessage(ctx) {
       return;
     }
     await ctx.reply('Reply with the correction text, for example: "make it HIGH".');
+    return;
+  }
+
+  const intent = await classifyIntent(incoming);
+  if (intent !== 'task' && intent !== 'unknown') {
+    await ctx.reply(INTENT_STUBS[intent] || '⚠️ Not sure what to do with that. Try rephrasing.');
     return;
   }
 

--- a/src/services/gemini.js
+++ b/src/services/gemini.js
@@ -121,12 +121,16 @@ function sanitizePatch(rawPatch) {
   return patch;
 }
 
-async function generateJson(prompt) {
+async function generateText(prompt) {
   const response = await withRetry(
     () => client.models.generateContent({ model: config.geminiModel, contents: prompt }),
     { retryOn: [503, 429], maxAttempts: 3, baseDelayMs: 1000 }
   );
-  const text = response.text || "";
+  return (response.text || "").trim();
+}
+
+async function generateJson(prompt) {
+  const text = await generateText(prompt);
   const parsed = safeParseJsonObject(text);
   if (!parsed) {
     throw new Error("Gemini returned invalid JSON.");
@@ -168,5 +172,6 @@ async function correctTask(existingTask, correctionText) {
 
 module.exports = {
   classifyTask,
-  correctTask
+  correctTask,
+  generateText
 };

--- a/src/services/intent-classifier.js
+++ b/src/services/intent-classifier.js
@@ -1,0 +1,24 @@
+'use strict';
+const { generateText } = require('./gemini');
+
+const INTENTS = ['task', 'note', 'reminder', 'contact', 'expense', 'question', 'correction', 'completion', 'unknown'];
+
+function buildIntentPrompt(text) {
+  return [
+    `Classify the intent of this home assistant message into exactly one of: ${INTENTS.join(', ')}`,
+    'Return only the intent word, nothing else.',
+    `Message: ${text}`
+  ].join('\n');
+}
+
+async function classifyIntent(text) {
+  try {
+    const raw = await generateText(buildIntentPrompt(text));
+    const intent = raw.toLowerCase().trim();
+    return INTENTS.includes(intent) ? intent : 'task';
+  } catch {
+    return 'task';
+  }
+}
+
+module.exports = { classifyIntent, INTENTS };

--- a/test/handlers/message.test.js
+++ b/test/handlers/message.test.js
@@ -46,6 +46,13 @@ require.cache[require.resolve('../../src/handlers/queue-session')] = {
 require.cache[require.resolve('../../src/services/witty-response')] = {
   exports: { generateWittyReply: mock.fn(async () => null) }
 };
+const classifyIntent = mock.fn(async () => 'task');
+require.cache[require.resolve('../../src/services/intent-classifier')] = {
+  exports: { classifyIntent }
+};
+require.cache[require.resolve('../../src/services/sentry')] = {
+  exports: { captureException: mock.fn() }
+};
 
 const { handleMessage } = require('../../src/handlers/message');
 
@@ -73,6 +80,8 @@ describe('handleMessage', () => {
     handleCorrection.mock.resetCalls();
     handleCompletionReply.mock.resetCalls();
     isCompletionWindowActive.mock.resetCalls();
+    classifyIntent.mock.resetCalls();
+    classifyIntent.mock.mockImplementation(async () => 'task');
 
     // Reset to default implementations
     classifyTask.mock.mockImplementation(async () => ({
@@ -251,5 +260,38 @@ describe('handleMessage', () => {
     assert.equal(createTask.mock.calls.length, 1);
     assert.equal(setRecentTask.mock.calls.length, 1);
     assert.equal(ctx.reply.mock.calls.length, 1);
+  });
+
+  describe('intent routing', () => {
+    it('routes task intent through task capture as normal', async () => {
+      classifyIntent.mock.mockImplementation(async () => 'task');
+      const ctx = makeCtx('fix the leaking tap');
+      await handleMessage(ctx);
+      assert.equal(classifyTask.mock.calls.length, 1);
+      assert.equal(createTask.mock.calls.length, 1);
+    });
+
+    it('routes unknown intent through task capture as fallback', async () => {
+      classifyIntent.mock.mockImplementation(async () => 'unknown');
+      const ctx = makeCtx('fix the leaking tap');
+      await handleMessage(ctx);
+      assert.equal(classifyTask.mock.calls.length, 1);
+    });
+
+    it('stubs note intent — does not capture as task', async () => {
+      classifyIntent.mock.mockImplementation(async () => 'note');
+      const ctx = makeCtx('remember to call the plumber');
+      await handleMessage(ctx);
+      assert.equal(createTask.mock.calls.length, 0);
+      assert.equal(ctx.reply.mock.calls.length, 1);
+    });
+
+    it('stubs expense intent — does not capture as task', async () => {
+      classifyIntent.mock.mockImplementation(async () => 'expense');
+      const ctx = makeCtx('spent 500 on groceries');
+      await handleMessage(ctx);
+      assert.equal(createTask.mock.calls.length, 0);
+      assert.equal(ctx.reply.mock.calls.length, 1);
+    });
   });
 });

--- a/test/unit/intent-classifier.test.js
+++ b/test/unit/intent-classifier.test.js
@@ -1,0 +1,60 @@
+'use strict';
+const { describe, it, mock, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const generateText = mock.fn(async () => 'task');
+
+require.cache[require.resolve('../../src/services/gemini')] = {
+  exports: {
+    classifyTask: mock.fn(),
+    correctTask: mock.fn(),
+    generateText
+  }
+};
+
+const { classifyIntent, INTENTS } = require('../../src/services/intent-classifier');
+
+describe('INTENTS', () => {
+  it('contains all 9 expected intents', () => {
+    const expected = ['task', 'note', 'reminder', 'contact', 'expense', 'question', 'correction', 'completion', 'unknown'];
+    assert.deepEqual([...INTENTS].sort(), expected.sort());
+  });
+});
+
+describe('classifyIntent', () => {
+  beforeEach(() => {
+    generateText.mock.resetCalls();
+    generateText.mock.mockImplementation(async () => 'task');
+  });
+
+  it('returns the intent string from Gemini when it is a known intent', async () => {
+    generateText.mock.mockImplementation(async () => 'note');
+    const result = await classifyIntent('remind me to buy milk');
+    assert.equal(result, 'note');
+  });
+
+  it('returns task when Gemini returns an unrecognised string', async () => {
+    generateText.mock.mockImplementation(async () => 'gibberish');
+    const result = await classifyIntent('fix the tap');
+    assert.equal(result, 'task');
+  });
+
+  it('returns task when Gemini throws', async () => {
+    generateText.mock.mockImplementation(async () => { throw new Error('AI down'); });
+    const result = await classifyIntent('fix the tap');
+    assert.equal(result, 'task');
+  });
+
+  it('is case-insensitive — normalises Gemini response to lowercase', async () => {
+    generateText.mock.mockImplementation(async () => 'EXPENSE');
+    const result = await classifyIntent('paid Rs 500 for groceries');
+    assert.equal(result, 'expense');
+  });
+
+  it('passes message text to generateText', async () => {
+    await classifyIntent('buy groceries');
+    assert.equal(generateText.mock.calls.length, 1);
+    const prompt = generateText.mock.calls[0].arguments[0];
+    assert.ok(prompt.includes('buy groceries'), 'prompt should include the message text');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/services/intent-classifier.js` with `classifyIntent(text)` — uses Gemini to return one of 9 intents; falls back to `'task'` on error or unrecognised response
- Extracts `generateText(prompt)` from `src/services/gemini.js` (raw text, no JSON parsing) and exports it; `generateJson` refactored to use it
- Updates `src/handlers/message.js` to classify intent before task capture; routes `'task'`/`'unknown'` through the existing flow; replies with a "coming soon" stub for the other 7 intents

**9 intents:** `task`, `note`, `reminder`, `contact`, `expense`, `question`, `correction`, `completion`, `unknown`

**Stub replies (all coming soon):** note, reminder, contact, expense, question, correction, completion

## Test plan
- [ ] `test/unit/intent-classifier.test.js` — 6 tests: INTENTS constant, known/unknown/error/case/prompt-passthrough
- [ ] `test/handlers/message.test.js` — 4 new routing tests: task/unknown → capture, note/expense → stub, no task created
- [ ] Full suite `node --test test/` — 273 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)