### PR TITLE
fix: code review findings CR-001–003 + WR-001/002/004 (tenant isolation, Sentry init, memory leak)

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -1,3 +1,6 @@
+const { initSentry } = require("./services/sentry");
+initSentry(); // must run before config load so boot errors are captured
+
 const { Telegraf } = require("telegraf");
 const { config } = require("./config");
 const { householdMiddleware } = require("./middleware/household");
@@ -8,10 +11,7 @@ const { handleMessage } = require("./handlers/message");
 const { purgeExpiredSessions } = require("./handlers/correction-session");
 const { startScheduler } = require("./cron/scheduler");
 const { info, error } = require("./utils/logger");
-const { initSentry } = require("./services/sentry");
 const { launchBot } = require("./utils/launch-bot");
-
-initSentry();
 
 const bot = new Telegraf(config.telegramBotToken);
 

--- a/src/handlers/commands.js
+++ b/src/handlers/commands.js
@@ -105,7 +105,7 @@ async function registerCommands(bot) {
     const tasks = await getIncompleteTasksByPriority(ctx.household.id);
     const task = findTaskByQuery(tasks, query);
     if (!task) return ctx.reply("❌ Task not found. Use /pending to see the list.");
-    await deleteTask(task.id);
+    await deleteTask(ctx.household.id, task.id);
     const witty = await generateWittyReply('task_deleted', { title: task.title });
     return ctx.reply(witty || `🗑️ Deleted: ${task.title}`);
   }));
@@ -171,12 +171,16 @@ async function registerCommands(bot) {
   }));
 
   bot.command("export", requireMember(async (ctx) => {
-    const payload = await buildExportPayload(ctx.household.id);
-    const json = JSON.stringify(payload, null, 2);
-    await ctx.replyWithDocument({
-      source: Buffer.from(json, 'utf8'),
-      filename: 'export.json'
-    });
+    try {
+      const payload = await buildExportPayload(ctx.household.id);
+      const json = JSON.stringify(payload, null, 2);
+      await ctx.replyWithDocument({
+        source: Buffer.from(json, 'utf8'),
+        filename: 'export.json'
+      });
+    } catch (err) {
+      await ctx.reply('⚠️ Export failed. Please try again.');
+    }
   }));
 
   bot.command("help", requireMember(async (ctx) => {

--- a/src/handlers/correction-session.js
+++ b/src/handlers/correction-session.js
@@ -7,16 +7,18 @@ function keyOf(chatId, userId) {
 }
 
 function setRecentTask(chatId, userId, task) {
-  recentTasks.set(keyOf(chatId, userId), task);
+  recentTasks.set(keyOf(chatId, userId), { task, addedAt: Date.now() });
 }
 
 function startSession(chatId, userId) {
-  const task = recentTasks.get(keyOf(chatId, userId));
-  if (!task) return false;
-  sessions.set(keyOf(chatId, userId), {
-    task,
-    expiresAt: Date.now() + TTL_MS
-  });
+  const key = keyOf(chatId, userId);
+  const entry = recentTasks.get(key);
+  if (!entry) return false;
+  if (entry.addedAt + TTL_MS < Date.now()) {
+    recentTasks.delete(key);
+    return false;
+  }
+  sessions.set(key, { task: entry.task, expiresAt: Date.now() + TTL_MS });
   return true;
 }
 
@@ -40,8 +42,12 @@ function clearSession(chatId, userId) {
 }
 
 function purgeExpiredSessions() {
+  const now = Date.now();
   for (const [key, session] of sessions) {
-    if (session.expiresAt < Date.now()) sessions.delete(key);
+    if (session.expiresAt < now) sessions.delete(key);
+  }
+  for (const [key, entry] of recentTasks) {
+    if (entry.addedAt + TTL_MS < now) recentTasks.delete(key);
   }
 }
 

--- a/src/handlers/correction.js
+++ b/src/handlers/correction.js
@@ -7,7 +7,11 @@ const { generateWittyReply } = require("../services/witty-response");
 async function handleCorrection(ctx, session) {
   const correctionText = ctx.message.text.trim();
   const patch = await correctTask(session.task, correctionText);
-  await updateTask(session.task.id, patch);
+  if (!Object.keys(patch).length) {
+    await ctx.reply('⚠️ Couldn\'t parse a correction from that. Try again, e.g. "make it HIGH" or "change area to Bathroom".');
+    return;
+  }
+  await updateTask(ctx.household.id, session.task.id, patch);
   clearSession(ctx.chat.id, ctx.from.id);
   const changes = formatTaskChanges(session.task, patch);
   const witty = await generateWittyReply('task_corrected', { title: session.task.title });

--- a/src/services/supabase.js
+++ b/src/services/supabase.js
@@ -80,10 +80,10 @@ async function createTask(householdId, task) {
   return data.id;
 }
 
-async function updateTask(id, patch) {
+async function updateTask(householdId, id, patch) {
   const mappedPatch = toDbPatch(patch);
   if (!Object.keys(mappedPatch).length) return;
-  const { error } = await supabase.from("tasks").update(mappedPatch).eq("id", id);
+  const { error } = await supabase.from("tasks").update(mappedPatch).eq("household_id", householdId).eq("id", id);
   if (error) throw error;
 }
 
@@ -156,8 +156,8 @@ async function bulkComplete(ids) {
   return completed;
 }
 
-async function deleteTask(id) {
-  const { error } = await supabase.from("tasks").delete().eq("id", id);
+async function deleteTask(householdId, id) {
+  const { error } = await supabase.from("tasks").delete().eq("household_id", householdId).eq("id", id);
   if (error) throw error;
 }
 
@@ -390,11 +390,13 @@ async function findUserByTelegramId(telegramId) {
 }
 
 async function getMemberByTelegramId(householdId, telegramId) {
+  const user = await findUserByTelegramId(telegramId);
+  if (!user) return null;
   const { data, error } = await supabase
     .from("household_members")
     .select("user_id, role, users(id, telegram_id, display_name)")
     .eq("household_id", householdId)
-    .eq("users.telegram_id", String(telegramId))
+    .eq("user_id", user.id)
     .maybeSingle();
   if (error) throw error;
   return data;

--- a/test/handlers/commands.test.js
+++ b/test/handlers/commands.test.js
@@ -231,7 +231,8 @@ describe('commands', () => {
       const ctx = makeCtx('/delete 1');
       await handlers['delete'](ctx);
       assert.equal(deleteTask.mock.calls.length, 1);
-      assert.equal(deleteTask.mock.calls[0].arguments[0], 't2');
+      assert.equal(deleteTask.mock.calls[0].arguments[0], 'h1'); // householdId
+      assert.equal(deleteTask.mock.calls[0].arguments[1], 't2'); // taskId
       assert.ok(ctx.reply.mock.calls[0].arguments[0].includes('Buy groceries'));
     });
 
@@ -242,7 +243,8 @@ describe('commands', () => {
       const ctx = makeCtx('/delete groceries');
       await handlers['delete'](ctx);
       assert.equal(deleteTask.mock.calls.length, 1);
-      assert.equal(deleteTask.mock.calls[0].arguments[0], 't2');
+      assert.equal(deleteTask.mock.calls[0].arguments[0], 'h1'); // householdId
+      assert.equal(deleteTask.mock.calls[0].arguments[1], 't2'); // taskId
     });
 
     it('replies "not found" when query matches nothing', async () => {

--- a/test/handlers/correction.test.js
+++ b/test/handlers/correction.test.js
@@ -27,6 +27,7 @@ const SESSION = {
 
 function makeCtx(correctionText) {
   return {
+    household: { id: 'h1' },
     message: { text: correctionText },
     chat: { id: 'chat1' },
     from: { id: 'user1' },
@@ -52,14 +53,25 @@ describe('handleCorrection', () => {
     assert.equal(correctTask.mock.calls[0].arguments[1], 'make it HIGH');
   });
 
-  it('calls updateTask with the task id and the returned patch', async () => {
+  it('calls updateTask with householdId, task id, and the returned patch', async () => {
     const patch = { criticality: 'CRITICAL', effortMins: 45 };
     correctTask.mock.mockImplementation(async () => patch);
     const ctx = makeCtx('change priority and effort');
     await handleCorrection(ctx, SESSION);
     assert.equal(updateTask.mock.calls.length, 1);
-    assert.equal(updateTask.mock.calls[0].arguments[0], 'task-1');
-    assert.deepEqual(updateTask.mock.calls[0].arguments[1], patch);
+    assert.equal(updateTask.mock.calls[0].arguments[0], 'h1');
+    assert.equal(updateTask.mock.calls[0].arguments[1], 'task-1');
+    assert.deepEqual(updateTask.mock.calls[0].arguments[2], patch);
+  });
+
+  it('does not call updateTask and keeps session open when patch is empty', async () => {
+    correctTask.mock.mockImplementation(async () => ({}));
+    const ctx = makeCtx('some unrecognisable text');
+    await handleCorrection(ctx, SESSION);
+    assert.equal(updateTask.mock.calls.length, 0);
+    assert.equal(clearSession.mock.calls.length, 0);
+    assert.equal(ctx.reply.mock.calls.length, 1);
+    assert.ok(ctx.reply.mock.calls[0].arguments[0].includes('parse'));
   });
 
   it('clears the session after correction', async () => {

--- a/test/unit/supabase.test.js
+++ b/test/unit/supabase.test.js
@@ -53,7 +53,7 @@ require.cache[require.resolve('../../src/utils/logger')] = {
   exports: { info: mock.fn(), warn: warnFn, error: mock.fn() }
 };
 
-const { bulkComplete, getIncompleteTasksByPriority, getAllHouseholdsWithSettings, getHousehold } = require('../../src/services/supabase');
+const { bulkComplete, getIncompleteTasksByPriority, getAllHouseholdsWithSettings, getHousehold, updateTask, deleteTask } = require('../../src/services/supabase');
 
 // ─── bulkComplete ─────────────────────────────────────────────────────────────
 
@@ -291,5 +291,42 @@ describe('getHousehold', () => {
     responseQueue.push({ data: { id: 'h2', name: 'Pro House', plan: 'pro' }, error: null });
     const result = await getHousehold('h2');
     assert.equal(result.plan, 'pro');
+  });
+});
+
+// ─── updateTask ───────────────────────────────────────────────────────────────
+
+describe('updateTask', () => {
+  beforeEach(() => { responseQueue = []; });
+
+  it('resolves without error when patch is applied', async () => {
+    responseQueue.push({ error: null });
+    await assert.doesNotReject(() => updateTask('h1', 'task-1', { criticality: 'HIGH' }));
+  });
+
+  it('does nothing and resolves when patch is empty', async () => {
+    await assert.doesNotReject(() => updateTask('h1', 'task-1', {}));
+    assert.equal(responseQueue.length, 0); // no DB call made
+  });
+
+  it('throws on DB error', async () => {
+    responseQueue.push({ error: new Error('db fail') });
+    await assert.rejects(() => updateTask('h1', 'task-1', { criticality: 'LOW' }));
+  });
+});
+
+// ─── deleteTask ───────────────────────────────────────────────────────────────
+
+describe('deleteTask', () => {
+  beforeEach(() => { responseQueue = []; });
+
+  it('resolves without error on success', async () => {
+    responseQueue.push({ error: null });
+    await assert.doesNotReject(() => deleteTask('h1', 'task-1'));
+  });
+
+  it('throws on DB error', async () => {
+    responseQueue.push({ error: new Error('db fail') });
+    await assert.rejects(() => deleteTask('h1', 'task-1'));
   });
 });


### PR DESCRIPTION
## Summary

Fixes 6 of 12 findings from the deep code review across phases 1–7 (all Critical + 3 Warning issues).

### Critical fixes
- **CR-001** — `updateTask`/`deleteTask` now require `householdId` as first arg, adding `.eq("household_id", ...)` to both queries. Prevents cross-tenant task mutation when service_role bypasses RLS. Callers updated: `correction.js` and `commands.js /delete`.
- **CR-002** — `initSentry()` moved to the very first line of `bot.js`, before `require("./config")`. Boot-time misconfiguration errors are now captured by Sentry.
- **CR-003** — `getMemberByTelegramId` rewritten as two-step lookup: find user via `findUserByTelegramId`, then filter `household_members` on `user_id`. The old `.eq("users.telegram_id", ...)` PostgREST filter was a no-op on the parent row.

### Warning fixes
- **WR-001** — `/export` handler wrapped in try/catch with user-facing error reply.
- **WR-002** — `recentTasks` entries now store `{ task, addedAt }` with TTL. `purgeExpiredSessions` now also purges stale `recentTasks` entries, eliminating the unbounded memory leak.
- **WR-004** — `handleCorrection` checks `Object.keys(patch).length` before calling `updateTask`. Empty patch now replies with a helpful retry prompt and keeps the session open.

### Tests
- 279 tests, 0 failures
- `supabase.test.js`: 5 new tests for `updateTask`/`deleteTask` new signatures
- `correction.test.js`: `makeCtx` adds `household`, updated `updateTask` arg assertion, new empty-patch test
- `commands.test.js`: `/delete` arg assertions updated to match `(householdId, taskId)` signature

## Remaining open issues
Issues #31–34 (IR-001–004) and #28/#30 (WR-003/WR-005) are tracked in GitHub and can be addressed separately.

## Test plan
- [ ] `node --test test/` — 279 pass, 0 fail
- [ ] Manual: send a message → task saved correctly
- [ ] Manual: `/delete 1` → task deleted (verify only that household's task is affected)
- [ ] Manual: type "correct" then gibberish → bot replies with retry prompt, session stays open

🤖 Generated with [Claude Code](https://claude.com/claude-code)