### PR TITLE
fix: remaining code review findings WR-003/005 + IR-001/002

### DIFF
--- a/src/handlers/commands.js
+++ b/src/handlers/commands.js
@@ -174,9 +174,11 @@ async function registerCommands(bot) {
     try {
       const payload = await buildExportPayload(ctx.household.id);
       const json = JSON.stringify(payload, null, 2);
+      const slug = ctx.household.name.replace(/\s+/g, '-').toLowerCase();
+      const date = new Date().toISOString().slice(0, 10);
       await ctx.replyWithDocument({
         source: Buffer.from(json, 'utf8'),
-        filename: 'export.json'
+        filename: `export-${slug}-${date}.json`
       });
     } catch (err) {
       await ctx.reply('⚠️ Export failed. Please try again.');

--- a/src/handlers/queue-session.js
+++ b/src/handlers/queue-session.js
@@ -2,30 +2,36 @@ const queueByChat = new Map();
 const completionSession = new Map();
 const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
 
-function setQueuedTasks(chatId, tasks) {
-  queueByChat.set(String(chatId), tasks);
+// Both maps are keyed by Telegram user ID (not chat ID).
+// In private DMs these happen to be equal, but user ID is the correct semantic key
+// for per-user state since the same user could interact from different chats in future.
+
+function setQueuedTasks(userId, tasks) {
+  queueByChat.set(String(userId), tasks);
 }
 
-function getQueuedTasks(chatId) {
-  return queueByChat.get(String(chatId)) || [];
+function getQueuedTasks(userId) {
+  return queueByChat.get(String(userId)) || [];
 }
 
-function startCompletionWindow(chatId) {
-  completionSession.set(String(chatId), Date.now() + TWO_HOURS_MS);
+function startCompletionWindow(userId) {
+  completionSession.set(String(userId), Date.now() + TWO_HOURS_MS);
 }
 
-function isCompletionWindowActive(chatId) {
-  const expiresAt = completionSession.get(String(chatId));
+function isCompletionWindowActive(userId) {
+  const expiresAt = completionSession.get(String(userId));
   if (!expiresAt) return false;
   if (expiresAt < Date.now()) {
-    completionSession.delete(String(chatId));
+    completionSession.delete(String(userId));
+    queueByChat.delete(String(userId));
     return false;
   }
   return true;
 }
 
-function endCompletionWindow(chatId) {
-  completionSession.delete(String(chatId));
+function endCompletionWindow(userId) {
+  completionSession.delete(String(userId));
+  queueByChat.delete(String(userId));
 }
 
 module.exports = {

--- a/src/services/gemini.js
+++ b/src/services/gemini.js
@@ -79,7 +79,8 @@ function sanitizeTask(raw, areas, originalText) {
   const title = String(raw.title || "").trim() || "Untitled task";
   const area = String(raw.area || "General").trim() || "General";
   const lowerAreas = new Set(areas.map((name) => name.toLowerCase()));
-  const isKnownArea = lowerAreas.has(area.toLowerCase());
+  // "General" is always seeded on household creation — never treat it as new
+  const isKnownArea = lowerAreas.has(area.toLowerCase()) || area.toLowerCase() === 'general';
   const recurrence = normalizeRecurrence(raw, originalText);
 
   return {

--- a/test/handlers/commands.test.js
+++ b/test/handlers/commands.test.js
@@ -403,7 +403,8 @@ describe('commands', () => {
 
       assert.equal(replyWithDocument.mock.calls.length, 1);
       const [doc] = replyWithDocument.mock.calls[0].arguments;
-      assert.equal(doc.filename, 'export.json');
+      const today = new Date().toISOString().slice(0, 10);
+      assert.equal(doc.filename, `export-the-sharma-house-${today}.json`);
       assert.ok(Buffer.isBuffer(doc.source), 'source should be a Buffer');
 
       const parsed = JSON.parse(doc.source.toString('utf8'));

--- a/test/unit/queue-session.test.js
+++ b/test/unit/queue-session.test.js
@@ -61,5 +61,26 @@ describe('queue-session', () => {
       endCompletionWindow('chat-end');
       assert.equal(isCompletionWindowActive('chat-end'), false);
     });
+
+    it('also clears queued tasks when window ends', () => {
+      setQueuedTasks('chat-cleanup', TASKS);
+      startCompletionWindow('chat-cleanup');
+      endCompletionWindow('chat-cleanup');
+      assert.deepEqual(getQueuedTasks('chat-cleanup'), []);
+    });
+  });
+
+  describe('isCompletionWindowActive — expired TTL clears queueByChat', () => {
+    it('clears queued tasks when window expires on check', () => {
+      setQueuedTasks('chat-ttl-clean', TASKS);
+      startCompletionWindow('chat-ttl-clean');
+
+      const originalNow = Date.now;
+      Date.now = () => originalNow() + 3 * 60 * 60 * 1000;
+      isCompletionWindowActive('chat-ttl-clean');
+      Date.now = originalNow;
+
+      assert.deepEqual(getQueuedTasks('chat-ttl-clean'), []);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes the remaining 4 fixable issues from the deep code review (WR-003, WR-005, IR-001, IR-002). IR-003 (prompt injection hardening) and IR-004 (missing tests for correction/completion/scheduler) are tracked as separate issues and left for dedicated PRs.

### Changes

- **WR-003** — `sanitizeTask` now treats `"General"` as always-known. `isNewArea` will never be true for "General", preventing repeated `addArea` calls + notifications on households that don't have it seeded yet. New households already get it via `seedDefaultAreas`.
- **WR-005** — Renamed `chatId` params to `userId` in `queue-session.js` (the map was always keyed by user/Telegram ID, not chat ID). Added a comment documenting why — in DMs they happen to be equal, but user ID is the correct semantic key.
- **IR-001** — `endCompletionWindow` now also clears the corresponding `queueByChat` entry. The expired-TTL path in `isCompletionWindowActive` does the same. Prevents stale task list accumulation.
- **IR-002** — `/export` filename is now scoped to household slug + date: `export-sharma-house-2026-05-02.json`. No more silent overwrites in downloads folder.

### Tests
- 281 tests, 0 failures
- `queue-session.test.js`: 2 new tests for cleanup behaviour on `endCompletionWindow` and TTL expiry
- `commands.test.js`: `/export` filename assertion updated to match scoped format

🤖 Generated with [Claude Code](https://claude.com/claude-code)